### PR TITLE
Test cluster credentials by pulling real test image

### DIFF
--- a/src/access_handlers/docker.rs
+++ b/src/access_handlers/docker.rs
@@ -9,14 +9,16 @@ use itertools::Itertools;
 use simplelog::*;
 use tokio;
 
-use crate::configparser::{config, get_config};
+use crate::configparser::{get_config, get_profile_config};
 
 /// container registry / daemon access checks
 #[tokio::main(flavor = "current_thread")] // make this a sync function
-pub async fn check(profile: &config::ProfileConfig) -> Result<()> {
+pub async fn check(profile_name: &str) -> Result<()> {
     // docker / podman does not keep track of whether registry credentials are
     // valid or not. to check if we do have valid creds, we need to do something
     // to present creds, like pulling an image.
+
+    let profile = get_profile_config(profile_name)?;
 
     let client = client()
         .await

--- a/src/access_handlers/frontend.rs
+++ b/src/access_handlers/frontend.rs
@@ -1,8 +1,9 @@
 use anyhow::{Error, Result};
 
-use crate::configparser::{config, CONFIG};
+use crate::configparser::{get_config, get_profile_config};
 
 /// frontend dashbard access checks
-pub fn check(profile: &config::ProfileConfig) -> Result<()> {
+pub fn check(profile_name: &str) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
     Ok(())
 }

--- a/src/access_handlers/kube.rs
+++ b/src/access_handlers/kube.rs
@@ -7,11 +7,13 @@ use kube;
 use simplelog::*;
 use tokio;
 
-use crate::configparser::{config, CONFIG};
+use crate::configparser::{config, get_config, get_profile_config};
 
 /// kubernetes access checks
 #[tokio::main(flavor = "current_thread")] // make this a sync function
-pub async fn check(profile: &config::ProfileConfig) -> Result<()> {
+pub async fn check(profile_name: &str) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
+
     // we need to make sure that:
     // a) can talk to the cluster
     // b) have the right permissions (a la `kubectl auth can-i`)

--- a/src/access_handlers/s3.rs
+++ b/src/access_handlers/s3.rs
@@ -1,8 +1,9 @@
 use anyhow::{Error, Result};
 
-use crate::configparser::{config, CONFIG};
+use crate::configparser::{get_config, get_profile_config};
 
 /// s3 bucket access checks
-pub fn check(profile: &config::ProfileConfig) -> Result<()> {
+pub fn check(profile_name: &str) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
     Ok(())
 }

--- a/src/commands/check_access.rs
+++ b/src/commands/check_access.rs
@@ -38,31 +38,25 @@ pub fn run(profile: &str, kubernetes: &bool, frontend: &bool, registry: &bool) {
 }
 
 /// checks a single profile (`profile`) for the given accesses
-fn check_profile(
-    profile_name: &str,
-    kubernetes: bool,
-    frontend: bool,
-    registry: bool,
-) -> Result<()> {
-    let profile = get_profile_config(profile_name)?;
-    info!("checking profile {profile_name}...");
+fn check_profile(name: &str, kubernetes: bool, frontend: bool, registry: bool) -> Result<()> {
+    info!("checking profile {name}...");
 
     // todo: this works but ehhh
     let mut results = vec![];
 
     if kubernetes {
-        results.push(access::kube::check(profile));
+        results.push(access::kube::check(name));
     }
     if frontend {
-        results.push(access::frontend::check(profile));
+        results.push(access::frontend::check(name));
     }
     if registry {
-        results.push(access::docker::check(profile));
+        results.push(access::docker::check(name));
     }
 
     // takes first Err in vec as Result() return
     results
         .into_iter()
         .collect::<Result<_>>()
-        .with_context(|| format!("Error in profile '{profile_name}'"))
+        .with_context(|| format!("Error in profile '{name}'"))
 }

--- a/tests/docker-compose.testregistry.yaml
+++ b/tests/docker-compose.testregistry.yaml
@@ -1,0 +1,17 @@
+# compose to create registry container and ui to see if images pushed ok
+services:
+  registry-server:
+    image: registry
+    ports:
+      - 5000:5000
+    container_name: registry-server
+
+  registry-ui:
+    image: joxit/docker-registry-ui
+    ports:
+      - 8000:80
+    user: root
+    environment:
+      - SINGLE_REGISTRY=true
+      - NGINX_PROXY_PASS_URL=http://registry-server:5000
+    container_name: registry-ui

--- a/tests/no_challenges/rcds.yaml
+++ b/tests/no_challenges/rcds.yaml
@@ -1,10 +1,13 @@
 flag_regex: dam{[a-zA-Z...]}
 
 registry:
-  domain: registry.example.com/damctf
+  # domain: registry.example.com/damctf
+  domain: localhost:5000/damctf
   # then environment variables e.g. REG_USER/REG_PASS
-  user: admin
-  pass: admin
+  build: &creds
+    user: admin
+    pass: admin
+  cluster: *creds
 
 defaults:
   difficulty: 1
@@ -17,13 +20,11 @@ points:
 
 deploy:
   # control challenge deployment status explicitly per environment/profile
-  staging:
-    misc/foo: true
-    rev/bar: false
+  test: {}
 
 profiles:
   # configure per-environment credentials etc
-  staging:
+  test:
     frontend_url: https://frontend.example
     # or environment var (recommended): FRONTEND_TOKEN_$PROFILE=secretsecretsecret
     frontend_token: secret


### PR DESCRIPTION
Since the build-time credentials check pushes an alpine image to a known location, try pulling that image with the in-cluster credentials to test pull access.

Also adds compose file to spin up local test registry with a web ui.