### PR TITLE
Allow some unused lints

### DIFF
--- a/src/builder/artifacts.rs
+++ b/src/builder/artifacts.rs
@@ -119,7 +119,7 @@ async fn extract_archive(
         buf.clear();
     }
 
-    z.finish();
+    z.finish()?;
 
     Ok(vec![chal.directory.join(archive_name)])
 }

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -194,7 +194,7 @@ pub async fn copy_file(container: &ContainerInfo, from: PathBuf, to: PathBuf) ->
 
     // extract single file from archive to disk
     // we only copied out one file, so this tar should only have one file
-    if let Some(mut entry_r) = tar.entries()?.next() {
+    if let Some(entry_r) = tar.entries()?.next() {
         let mut entry = entry_r?;
         trace!("got entry: {:?}", entry.path());
         let mut target = File::create(&to)?;

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -152,7 +152,7 @@ fn install_helm_chart(
 
     // stream output to stdout
     let reader = helm_cmd.reader()?;
-    let mut lines = BufReader::new(reader).lines();
+    let lines = BufReader::new(reader).lines();
 
     for item in lines {
         match item {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused_variables, unused_imports)]
 // todo!: remove ^ later
 // we dont need unused variables etc warnings while we're working on it
 


### PR DESCRIPTION
We still probably don't want unused imports or variables to cause warnings, but this codebase is large enough that warning on unconsumed `Result`s or `mut`s are a good idea.