### PR TITLE
Prep for deploy command

### DIFF
--- a/src/access_handlers/docker.rs
+++ b/src/access_handlers/docker.rs
@@ -23,6 +23,7 @@ pub async fn check(profile_name: &str) -> Result<()> {
     let registry_config = &get_config()?.registry;
 
     let client = docker().await?;
+
     // build test image string
     // registry.example.com/somerepo/testimage:pleaseignore
     let test_image = format!("{}/credstestimage", registry_config.domain);

--- a/src/access_handlers/s3.rs
+++ b/src/access_handlers/s3.rs
@@ -3,6 +3,7 @@ use s3;
 use simplelog::*;
 use tokio;
 
+use crate::clients::{bucket_client, bucket_client_anonymous};
 use crate::configparser::{
     config::{ProfileConfig, S3Config},
     get_config, get_profile_config,
@@ -59,38 +60,4 @@ pub async fn check(profile_name: &str) -> Result<()> {
     bucket.delete_object(test_file.0).await?;
 
     Ok(())
-}
-
-/// create bucket client for passed profile config
-pub fn bucket_client(config: &S3Config) -> Result<Box<s3::Bucket>> {
-    trace!("creating bucket client");
-    // TODO: once_cell this so it reuses the same bucket?
-    let region = s3::Region::Custom {
-        region: config.region.clone(),
-        endpoint: config.endpoint.clone(),
-    };
-    let creds = s3::creds::Credentials::new(
-        Some(&config.access_key),
-        Some(&config.secret_key),
-        None,
-        None,
-        None,
-    )?;
-    let bucket = s3::Bucket::new(&config.bucket_name, region, creds)?.with_path_style();
-
-    Ok(bucket)
-}
-
-/// create public/anonymous bucket client for passed profile config
-pub fn bucket_client_anonymous(config: &S3Config) -> Result<Box<s3::Bucket>> {
-    trace!("creating anon bucket client");
-    // TODO: once_cell this so it reuses the same bucket?
-    let region = s3::Region::Custom {
-        region: config.region.clone(),
-        endpoint: config.endpoint.clone(),
-    };
-    let creds = s3::creds::Credentials::anonymous()?;
-    let bucket = s3::Bucket::new(&config.bucket_name, region, creds)?.with_path_style();
-
-    Ok(bucket)
 }

--- a/src/builder/artifacts.rs
+++ b/src/builder/artifacts.rs
@@ -48,7 +48,7 @@ pub async fn extract_asset(
 async fn extract_files(
     chal: &ChallengeConfig,
     container: &docker::ContainerInfo,
-    files: &Vec<String>,
+    files: &[PathBuf],
 ) -> Result<Vec<PathBuf>> {
     debug!(
         "extracting {} files without renaming: {:?}",
@@ -56,12 +56,10 @@ async fn extract_files(
         files
     );
 
-    try_join_all(files.iter().map(|f| {
-        let from = PathBuf::from(f);
+    try_join_all(files.iter().map(|from| async {
         // use basename of source file as target name
         let to = chal.directory.join(from.file_name().unwrap());
-
-        docker::copy_file(container, from, to)
+        docker::copy_file(container, from, &to).await
     }))
     .await
 }
@@ -70,13 +68,12 @@ async fn extract_files(
 async fn extract_rename(
     chal: &ChallengeConfig,
     container: &docker::ContainerInfo,
-    file: &str,
-    new_name: &str,
+    file: &Path,
+    new_name: &Path,
 ) -> Result<Vec<PathBuf>> {
     debug!("extracting file {:?} renamed to {:?}", file, new_name);
 
-    let new_file =
-        docker::copy_file(container, PathBuf::from(file), PathBuf::from(new_name)).await?;
+    let new_file = docker::copy_file(container, file, new_name).await?;
 
     Ok(vec![new_file])
 }
@@ -85,8 +82,9 @@ async fn extract_rename(
 async fn extract_archive(
     chal: &ChallengeConfig,
     container: &docker::ContainerInfo,
-    files: &Vec<String>,
-    archive_name: &str,
+    // files: &Vec<PathBuf>,
+    files: &[PathBuf],
+    archive_name: &Path,
 ) -> Result<Vec<PathBuf>> {
     debug!(
         "extracting {} files {:?} into archive {:?}",
@@ -97,21 +95,19 @@ async fn extract_archive(
 
     // copy all listed files to tempdir
     let tempdir = tempdir_in(".")?;
-    let copied_files = try_join_all(files.iter().map(|f| {
-        let from = PathBuf::from(f);
+    let copied_files = try_join_all(files.iter().map(|from| async {
         let to = tempdir.path().join(from.file_name().unwrap());
-
-        docker::copy_file(container, from, to)
+        docker::copy_file(container, from, &to).await
     }))
     .await?;
 
-    zip_files(&chal.directory.join(archive_name), copied_files)?;
+    zip_files(&chal.directory.join(archive_name), &copied_files)?;
 
     Ok(vec![chal.directory.join(archive_name)])
 }
 
 /// Add multiple local `files` to a zipfile at `zip_name`
-fn zip_files(archive_name: &Path, files: Vec<PathBuf>) -> Result<PathBuf> {
+pub fn zip_files(archive_name: &Path, files: &[PathBuf]) -> Result<PathBuf> {
     debug!("creating zip at {:?}", archive_name);
     let zipfile = File::create(archive_name)?;
     let mut z = zip::ZipWriter::new(zipfile);
@@ -119,7 +115,7 @@ fn zip_files(archive_name: &Path, files: Vec<PathBuf>) -> Result<PathBuf> {
 
     let mut buf = vec![];
     for path in files.iter() {
-        trace!("adding {:?} to zip", &path);
+        trace!("adding {:?} to zip", path);
         // TODO: dont read entire file into memory
         File::open(path)?.read_to_end(&mut buf)?;
         // TODO: should this always do basename? some chals might need specific

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -122,7 +122,6 @@ pub async fn push_image(image_tag: &str, creds: &UserPass) -> Result<String> {
     Ok(tag.to_string())
 }
 
-#[tokio::main(flavor = "current_thread")] // make this a sync function
 pub async fn create_container(image_tag: &str, name: &str) -> Result<ContainerInfo> {
     debug!("creating container {name:?} from image {image_tag:?}");
     let client = docker().await?;
@@ -143,7 +142,6 @@ pub async fn create_container(image_tag: &str, name: &str) -> Result<ContainerIn
     })
 }
 
-#[tokio::main(flavor = "current_thread")] // make this a sync function
 pub async fn remove_container(container: ContainerInfo) -> Result<()> {
     debug!("removing container {}", &container.name);
     let client = docker().await?;
@@ -182,7 +180,10 @@ pub async fn copy_file(container: &ContainerInfo, from: &Path, to: &Path) -> Res
         });
 
     // collect byte stream chunks into full file
-    let mut temptar = Builder::new().suffix(".tar").tempfile_in(".")?;
+    let mut temptar = Builder::new()
+        .prefix(".beavercds-")
+        .suffix(".tar")
+        .tempfile_in(".")?;
     while let Some(chunk) = dl_stream.next().await {
         temptar.as_file_mut().write_all(&chunk?)?;
     }

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -157,7 +157,7 @@ pub async fn remove_container(container: ContainerInfo) -> Result<()> {
     Ok(())
 }
 
-pub async fn copy_file(container: &ContainerInfo, from: PathBuf, to: PathBuf) -> Result<PathBuf> {
+pub async fn copy_file(container: &ContainerInfo, from: &Path, to: &Path) -> Result<PathBuf> {
     trace!("copying {}:{from:?} to {to:?}", container.name);
 
     let client = docker().await?;
@@ -197,7 +197,7 @@ pub async fn copy_file(container: &ContainerInfo, from: PathBuf, to: PathBuf) ->
     if let Some(mut entry_r) = tar.entries()?.next() {
         let mut entry = entry_r?;
         trace!("got entry: {:?}", entry.path());
-        let mut target = File::create(&to)?;
+        let mut target = File::create(to)?;
         io::copy(&mut entry, &mut target)?;
     } else {
         bail!(

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -51,10 +51,10 @@ pub fn build_challenges(
     profile_name: &str,
     push: bool,
     extract_artifacts: bool,
-) -> Result<Vec<BuildResult>> {
+) -> Result<Vec<(&ChallengeConfig, BuildResult)>> {
     enabled_challenges(profile_name)?
-        .iter()
-        .map(|chal| build_challenge(profile_name, chal, push, extract_artifacts))
+        .into_iter()
+        .map(|chal| build_challenge(profile_name, chal, push, extract_artifacts).map(|r| (chal, r)))
         .collect::<Result<_>>()
 }
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -27,16 +27,24 @@ macro_rules! image_tag_str {
         "{registry}/{challenge}-{container}:{profile}"
     };
 }
+pub(super) use image_tag_str;
 
 /// Information about all of a challenge's build artifacts.
 #[derive(Debug)]
 pub struct BuildResult {
     /// Container image tags of all containers in the challenge, if the challenge has container images.
     /// Will be empty if challenge has no images built from source.
-    tags: Vec<String>,
+    tags: Vec<TagWithSource>,
     /// Path on disk to local assets (both built and static).
     /// Will be empty if challenge has no file assets
     assets: Vec<PathBuf>,
+}
+
+/// Tag string with added context of where it came from (built locally or an upstream image)
+#[derive(Debug)]
+pub enum TagWithSource {
+    Upstream(String),
+    Built(String),
 }
 
 /// Build all enabled challenges for the given profile. Returns tags built
@@ -69,40 +77,43 @@ fn build_challenge(
     built.tags = chal
         .pods
         .iter()
-        .filter_map(|p| match &p.image_source {
-            // ignore any pods that use existing images
-            Image(_) => None,
+        .map(|p| match &p.image_source {
+            Image(tag) => Ok(TagWithSource::Upstream(tag.to_string())),
             // build any pods that need building
-            Build(b) => {
-                let tag = format!(
-                    image_tag_str!(),
-                    registry = config.registry.domain,
-                    challenge = chal.name,
-                    container = p.name,
-                    profile = profile_name
-                );
-                Some(
-                    docker::build_image(&chal.directory, b, &tag).with_context(|| {
-                        format!(
-                            "error building image {} for chal {}",
-                            p.name,
-                            chal.directory.to_string_lossy()
-                        )
-                    }),
-                )
+            Build(build) => {
+                let tag = chal.container_tag_for_pod(profile_name, &p.name)?;
+
+                let res = docker::build_image(&chal.directory, build, &tag).with_context(|| {
+                    format!(
+                        "error building image {} for chal {}",
+                        p.name,
+                        chal.directory.to_string_lossy()
+                    )
+                });
+                // map result tag string into enum
+                res.map(TagWithSource::Built)
             }
         })
         .collect::<Result<_>>()?;
 
     if push {
+        // only need to push tags we actually built
+        let tags_to_push = built
+            .tags
+            .iter()
+            .filter_map(|t| match t {
+                TagWithSource::Built(t) => Some(t),
+                TagWithSource::Upstream(_) => None,
+            })
+            .collect_vec();
+
         debug!(
             "pushing {} tags for chal {:?}",
-            built.tags.len(),
+            tags_to_push.len(),
             chal.directory
         );
 
-        built
-            .tags
+        tags_to_push
             .iter()
             .map(|tag| {
                 docker::push_image(tag, &config.registry.build)
@@ -114,29 +125,22 @@ fn build_challenge(
     if extract_artifacts {
         info!("extracting build artifacts for chal {:?}", chal.directory);
 
-        // find the matching tag for Provide entries that have a `from:` source
+        // associate file `Provide` entries that have a `from:` source with their corresponding container image
         let image_assoc = chal
             .provide
             .iter()
             .filter_map(|p| {
-                p.from.as_ref().map(|f| {
-                    (
-                        p,
-                        format!(
-                            image_tag_str!(),
-                            registry = config.registry.domain,
-                            challenge = chal.name,
-                            container = f,
-                            profile = profile_name
-                        ),
-                    )
-                })
+                p.from
+                    .as_ref()
+                    .map(|f| (p, chal.container_tag_for_pod(profile_name, f)))
             })
             .collect_vec();
 
         built.assets = image_assoc
             .into_iter()
             .map(|(p, tag)| {
+                let tag = tag?;
+
                 let name = format!(
                     "asset-container-{}-{}",
                     chal.directory.to_string_lossy().replace("/", "-"),

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -123,55 +123,55 @@ fn build_challenge(
     if extract_artifacts {
         info!("extracting build artifacts for chal {:?}", chal.directory);
 
-        let (provide_container, provide_static): (Vec<_>, Vec<_>) =
-            chal.provide.iter().partition(|p| p.from.is_some());
+        // let (provide_container, provide_static): (Vec<_>, Vec<_>) =
+        //     chal.provide.iter().partition(|p| p.from.is_some());
 
-        let extracted_files = provide_container
-            .iter()
-            // associate container `Provide` entries with their corresponding container image
-            .map(|provide| {
-                (
-                    provide,
-                    chal.container_tag_for_pod(profile_name, provide.from.as_ref().unwrap()),
-                )
-            })
-            // extract each container provide entry
-            .map(|(p, tag)| {
-                let tag = tag?;
+        // let extracted_files = provide_container
+        //     .iter()
+        //     // associate container `Provide` entries with their corresponding container image
+        //     .map(|provide| {
+        //         (
+        //             provide,
+        //             chal.container_tag_for_pod(profile_name, provide.from.as_ref().unwrap()),
+        //         )
+        //     })
+        //     // extract each container provide entry
+        //     .map(|(p, tag)| {
+        //         let tag = tag?;
 
-                let name = format!(
-                    "asset-container-{}-{}",
-                    chal.directory.to_string_lossy().replace("/", "-"),
-                    p.from.clone().unwrap()
-                );
-                let container = docker::create_container(&tag, &name)?;
+        //         let name = format!(
+        //             "asset-container-{}-{}",
+        //             chal.directory.to_string_lossy().replace("/", "-"),
+        //             p.from.clone().unwrap()
+        //         );
+        //         let container = docker::create_container(&tag, &name)?;
 
-                let asset_result =
-                    artifacts::extract_asset(chal, p, &container).with_context(|| {
-                        format!(
-                            "failed to extract build artifacts for chal {:?} container {:?}",
-                            chal.directory,
-                            p.from.clone().unwrap()
-                        )
-                    });
+        //         let asset_result =
+        //             artifacts::extract_asset(chal, p, &container).with_context(|| {
+        //                 format!(
+        //                     "failed to extract build artifacts for chal {:?} container {:?}",
+        //                     chal.directory,
+        //                     p.from.clone().unwrap()
+        //                 )
+        //             });
 
-                // clean up container even if it failed
-                docker::remove_container(container)?;
+        //         // clean up container even if it failed
+        //         docker::remove_container(container)?;
 
-                asset_result
-            })
-            .flatten_ok()
-            .collect::<Result<Vec<_>>>()?;
+        //         asset_result
+        //     })
+        //     .flatten_ok()
+        //     .collect::<Result<Vec<_>>>()?;
 
-        // handle potentially zipping up local files as well
-        let local_files = provide_static.iter().map(|provide| {
-            match provide.as_file.as_ref() {
-                // no archiving needed, pass files as-is
-                None => Ok(provide.include.clone()),
-                // need to archive multiple files into zip
-                Some(as_) => artifacts::zip_files(as_, provide.include.as_ref()).map(|z| vec![z]),
-            }
-        });
+        // // handle potentially zipping up local files as well
+        // let local_files = provide_static.iter().map(|provide| {
+        //     match provide.as_file.as_ref() {
+        //         // no archiving needed, pass files as-is
+        //         None => Ok(provide.include.clone()),
+        //         // need to archive multiple files into zip
+        //         Some(as_) => artifacts::zip_files(as_, provide.include.as_ref()).map(|z| vec![z]),
+        //     }
+        // });
 
         info!("extracted artifacts: {:?}", built.assets);
     }

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -9,6 +9,7 @@ use kube::{
     core::ResourceExt,
     discovery::{ApiCapabilities, ApiResource, Discovery, Scope},
 };
+use s3;
 use simplelog::*;
 
 use crate::configparser::config;
@@ -47,6 +48,44 @@ pub async fn engine_type() -> EngineType {
     } else {
         EngineType::Docker
     }
+}
+
+//
+// S3 stuff
+//
+
+/// create bucket client for passed profile config
+pub fn bucket_client(config: &config::S3Config) -> Result<Box<s3::Bucket>> {
+    trace!("creating bucket client");
+    // TODO: once_cell this so it reuses the same bucket?
+    let region = s3::Region::Custom {
+        region: config.region.clone(),
+        endpoint: config.endpoint.clone(),
+    };
+    let creds = s3::creds::Credentials::new(
+        Some(&config.access_key),
+        Some(&config.secret_key),
+        None,
+        None,
+        None,
+    )?;
+    let bucket = s3::Bucket::new(&config.bucket_name, region, creds)?.with_path_style();
+
+    Ok(bucket)
+}
+
+/// create public/anonymous bucket client for passed profile config
+pub fn bucket_client_anonymous(config: &config::S3Config) -> Result<Box<s3::Bucket>> {
+    trace!("creating anon bucket client");
+    // TODO: once_cell this so it reuses the same bucket?
+    let region = s3::Region::Custom {
+        region: config.region.clone(),
+        endpoint: config.endpoint.clone(),
+    };
+    let creds = s3::creds::Credentials::anonymous()?;
+    let bucket = s3::Bucket::new(&config.bucket_name, region, creds)?.with_path_style();
+
+    Ok(bucket)
 }
 
 //

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -27,6 +27,9 @@ use crate::configparser::{config, get_config, get_profile_config};
 // Some components can or must be deployed and configured ahead of time, like
 // the ingress controller, cert-manager, and external-dns
 
+// install these charts into this namespace
+pub const INGRESS_NAMESPACE: &str = "ingress";
+
 pub async fn install_ingress(profile: &config::ProfileConfig) -> Result<()> {
     info!("deploying ingress-nginx chart...");
 
@@ -38,7 +41,7 @@ pub async fn install_ingress(profile: &config::ProfileConfig) -> Result<()> {
         "ingress-nginx",
         Some("https://kubernetes.github.io/ingress-nginx"),
         "ingress-nginx",
-        "ingress",
+        INGRESS_NAMESPACE,
         VALUES,
     )
     .context("failed to install ingress-nginx helm chart")
@@ -55,7 +58,7 @@ pub async fn install_certmanager(profile: &config::ProfileConfig) -> Result<()> 
         "cert-manager",
         Some("https://charts.jetstack.io"),
         "cert-manager",
-        "ingress",
+        INGRESS_NAMESPACE,
         VALUES,
     )?;
 
@@ -87,7 +90,7 @@ pub async fn install_extdns(profile: &config::ProfileConfig) -> Result<()> {
         "oci://registry-1.docker.io/bitnamicharts/external-dns",
         None,
         "external-dns",
-        "ingress",
+        INGRESS_NAMESPACE,
         &values,
     )
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -8,8 +8,8 @@ use crate::configparser::{get_config, get_profile_config};
 pub fn run(profile_name: &str, push: &bool, extract: &bool) {
     info!("building images...");
 
-    let tags = match build_challenges(profile_name, *push, *extract) {
-        Ok(tags) => tags,
+    let results = match build_challenges(profile_name, *push, *extract) {
+        Ok(results) => results,
         Err(e) => {
             error!("{e:?}");
             exit(1)

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -22,6 +22,8 @@ pub async fn run(profile_name: &str, _no_build: &bool, _dry_run: &bool) {
         error!("{e:?}");
         exit(1);
     }
+
+    // let build_result =
 }
 
 /// check to make sure that the needed ingress charts are deployed and running
@@ -81,9 +83,11 @@ async fn check_setup(profile: &ProfileConfig) -> Result<()> {
 
     if !missing.is_empty() {
         // if any errors are present, collect/reduce them all into one error via
-        // anyhow context() calls. TODO: should this be in run() to present
-        // errors there instead of chaining and returning one combined Error
-        // here?
+        // anyhow context() calls.
+        //
+        // TODO: this should probably be returning Vec<Error> instead of a
+        // single Error chain. should this be in run() to present errors there
+        // instead of chaining and returning one combined Error here?
         #[allow(clippy::manual_try_fold)] // need to build the Result ourselves
         missing
             .iter()

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -7,14 +7,15 @@ use std::env::current_exe;
 use std::process::exit;
 
 use crate::clients::kube_client;
-use crate::cluster_setup as setup;
+use crate::cluster_setup;
 use crate::configparser::config::ProfileConfig;
 use crate::configparser::{get_config, get_profile_config};
 
-#[tokio::main(flavor = "current_thread")] // make this a sync function
-pub async fn run(profile_name: &str, _no_build: &bool, _dry_run: &bool) {
-    info!("deploying challenges...");
+use crate::builder::build_challenges;
+use crate::deploy::{deploy_challenges, update_frontend, upload_assets};
 
+#[tokio::main(flavor = "current_thread")] // make this a sync function
+pub async fn run(profile_name: &str, no_build: &bool, _dry_run: &bool) {
     let profile = get_profile_config(profile_name).unwrap();
 
     // has the cluster been setup?
@@ -23,13 +24,57 @@ pub async fn run(profile_name: &str, _no_build: &bool, _dry_run: &bool) {
         exit(1);
     }
 
-    // let build_result =
+    // build before deploying
+    if *no_build {
+        warn!("");
+        warn!("Not building before deploying! are you sure this is a good idea?");
+        warn!("");
+    }
+
+    info!("building challenges...");
+    let build_results = match build_challenges(profile_name, true, true) {
+        Ok(result) => result,
+        Err(e) => {
+            error!("{e:?}");
+            exit(1);
+        }
+    };
+
+    // deploy needs to:
+    // A) render kubernetes manifests
+    //    - namespace, deployment, service, ingress
+    //    - upgrade ingress config with new listen ports
+    //
+    // B) upload asset files to bucket
+    //
+    // C) update frontend with new state of challenges
+
+    // A)
+    info!("deploying challenges...");
+    if let Err(e) = deploy_challenges(profile_name, &build_results).await {
+        error!("{e:?}");
+        exit(1);
+    }
+
+    // B)
+    info!("deploying challenges...");
+    if let Err(e) = upload_assets(profile_name, &build_results).await {
+        error!("{e:?}");
+        exit(1);
+    }
+
+    // A)
+    info!("deploying challenges...");
+    if let Err(e) = update_frontend(profile_name, &build_results).await {
+        error!("{e:?}");
+        exit(1);
+    }
 }
 
 /// check to make sure that the needed ingress charts are deployed and running
 async fn check_setup(profile: &ProfileConfig) -> Result<()> {
     let kube = kube_client(profile).await?;
-    let secrets: kube::Api<Secret> = kube::Api::namespaced(kube, setup::INGRESS_NAMESPACE);
+    let secrets: kube::Api<Secret> = kube::Api::namespaced(kube, cluster_setup::INGRESS_NAMESPACE);
 
     let all_releases = secrets
         .list_metadata(&ListParams::default().labels("owner=helm"))
@@ -93,12 +138,15 @@ async fn check_setup(profile: &ProfileConfig) -> Result<()> {
             .iter()
             .fold(Err(anyhow!("")), |e, reason| match reason {
                 ChartFailure::Missing(c) => e.with_context(|| {
-                    format!("chart {}/{c} is not deployed", setup::INGRESS_NAMESPACE)
+                    format!(
+                        "chart {}/{c} is not deployed",
+                        cluster_setup::INGRESS_NAMESPACE
+                    )
                 }),
                 ChartFailure::DeploymentFailed(c) => e.with_context(|| {
                     format!(
                         "chart {}/{c} is in a failed state",
-                        setup::INGRESS_NAMESPACE
+                        cluster_setup::INGRESS_NAMESPACE
                     )
                 }),
             })

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,3 +1,110 @@
-pub fn run(_profile: &str, _no_build: &bool, _dry_run: &bool) {
-    println!("running deploy!");
+use anyhow::{anyhow, bail, Context, Error, Result};
+use itertools::Itertools;
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::ListParams;
+use simplelog::*;
+use std::env::current_exe;
+use std::process::exit;
+
+use crate::clients::kube_client;
+use crate::cluster_setup::{self as setup, INGRESS_NAMESPACE};
+use crate::configparser::config::ProfileConfig;
+use crate::configparser::{get_config, get_profile_config};
+
+#[tokio::main(flavor = "current_thread")] // make this a sync function
+pub async fn run(profile_name: &str, _no_build: &bool, _dry_run: &bool) {
+    info!("deploying challenges...");
+
+    let profile = get_profile_config(profile_name).unwrap();
+
+    // has the cluster been setup?
+    if let Err(e) = check_setup(profile).await {
+        error!("{e:?}");
+        exit(1);
+    }
+}
+
+/// check to make sure that the
+async fn check_setup(profile: &ProfileConfig) -> Result<()> {
+    let kube = kube_client(profile).await?;
+    let secrets: kube::Api<Secret> = kube::Api::namespaced(kube, setup::INGRESS_NAMESPACE);
+
+    let all_releases = secrets
+        .list_metadata(&ListParams::default().labels("owner=helm"))
+        .await?;
+
+    // pull helm release version from secret label
+    macro_rules! helm_version {
+        ($s:ident) => {
+            $s.get("version")
+                .unwrap_or(&"".to_string())
+                .parse::<usize>()
+                .unwrap_or(0)
+        };
+    }
+    let expected_charts = ["ingress-nginx", "cert-manager", "external-dns"];
+    let latest_releases = expected_charts
+        .iter()
+        .map(|chart| {
+            // pick latest release
+            all_releases
+                .iter()
+                .map(|r| r.metadata.labels.as_ref().unwrap())
+                .filter(|rl| rl.get("name") == Some(&chart.to_string()))
+                .max_by(|a, b| helm_version!(a).cmp(&helm_version!(b)))
+        })
+        .collect_vec();
+
+    enum ChartFailure {
+        Missing(String),
+        DeploymentFailed(String),
+    }
+
+    // make sure all releases are present and deployed successfully
+    let missing = latest_releases
+        .iter()
+        .zip(expected_charts)
+        .filter_map(|(r, c)| {
+            // is label status=deployed ?
+            if r.is_none() {
+                return Some(ChartFailure::Missing(c.to_string()));
+            }
+
+            if r.unwrap().get("status") == Some(&"deployed".to_string()) {
+                // all is good
+                None
+            } else {
+                Some(ChartFailure::DeploymentFailed(c.to_string()))
+            }
+        })
+        .collect_vec();
+
+    if !missing.is_empty() {
+        // if any errors are present, collect/reduce them all into one error via
+        // anyhow context() calls. TODO: should this be in run() to present
+        // errors there instead of chaining and returning one combined Error
+        // here?
+        missing
+            .iter()
+            .fold(Err(anyhow!("")), |e, reason| match reason {
+                ChartFailure::Missing(c) => {
+                    e.with_context(|| format!("chart {}/{c} is not deployed", INGRESS_NAMESPACE))
+                }
+                ChartFailure::DeploymentFailed(c) => e.with_context(|| {
+                    format!("chart {}/{c} is in a failed state", INGRESS_NAMESPACE)
+                }),
+            })
+            .with_context(|| {
+                format!(
+                    "cluster has not been set up with needed charts (run `{} cluster-setup`)",
+                    current_exe()
+                        .unwrap()
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                )
+            })
+    } else {
+        Ok(())
+    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,3 +3,6 @@ pub mod check_access;
 pub mod cluster_setup;
 pub mod deploy;
 pub mod validate;
+
+// These modules should not do much and act mostly as a thunk to handle
+// displaying outputs/errors of the real function.

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -141,6 +141,8 @@ pub struct ChallengeConfig {
     pods: Vec<Pod>, // optional if no containers used
 }
 impl ChallengeConfig {
+    /// Return the container image tag for the pod; either the upstream image or
+    /// the tag to be built if the image is to be built from source.
     pub fn container_tag_for_pod(&self, profile_name: &str, pod_name: &str) -> Result<String> {
         let config = get_config()?;
         let pod = self
@@ -180,7 +182,7 @@ enum FlagType {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[fully_pub]
 struct FilePath {
-    file: String,
+    file: PathBuf,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -215,11 +217,11 @@ struct ProvideConfig {
     /// they are zipped into an archive with this filename. If this is omitted,
     /// each file(s) are listed individually with no renaming.
     #[serde(default, rename = "as")]
-    as_file: Option<String>,
+    as_file: Option<PathBuf>,
 
     /// List of files to read from the repo or container. If reading from the
     /// repo source files, only relative paths are supported.
-    include: Vec<String>,
+    include: Vec<PathBuf>,
 }
 impl FromStr for ProvideConfig {
     type Err = Void;
@@ -227,7 +229,7 @@ impl FromStr for ProvideConfig {
         Ok(ProvideConfig {
             from: None,
             as_file: None,
-            include: vec![s.to_string()],
+            include: vec![PathBuf::from(s)],
         })
     }
 }

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -180,6 +180,7 @@ enum FlagType {
 }
 
 // Parse each distinct kind of Provide action as a separate enum variant
+// TODO: enforce relative/absolute paths for repo/container Provide's (`validator` crate?)
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 #[fully_pub]

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1,28 +1,33 @@
+use std::path::PathBuf;
+
 use anyhow::{anyhow, bail, Context, Error, Result};
 use itertools::Itertools;
 use simplelog::*;
 
+use crate::builder::BuildResult;
 use crate::clients::{bucket_client, kube_client};
 use crate::cluster_setup as setup;
 use crate::configparser::config::ProfileConfig;
 use crate::configparser::{enabled_challenges, get_config, get_profile_config};
 
 /// Render challenge manifest templates and apply to cluster
-pub async fn deploy_challenges(profile_name: &str) -> Result<()> {
+pub async fn deploy_challenges(profile_name: &str, build_results: &[BuildResult]) -> Result<()> {
     let profile = get_profile_config(profile_name)?;
+    let enabled_challenges = enabled_challenges(profile_name)?;
 
     todo!()
 }
 
 /// Upload files to frontend asset bucket
 /// Returns urls of upload files.
-pub async fn upload_assets(profile_name: &str) -> Result<Vec<String>> {
+pub async fn upload_assets(
+    profile_name: &str,
+    build_results: &[BuildResult],
+) -> Result<Vec<String>> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 
     let bucket = bucket_client(&profile.s3)?;
-
-    for chal in enabled_challenges {}
 
     todo!()
 
@@ -31,7 +36,9 @@ pub async fn upload_assets(profile_name: &str) -> Result<Vec<String>> {
 }
 
 /// Sync deployed challenges with rCTF frontend
-pub async fn update_frontend(profile_name: &str) -> Result<()> {
+pub async fn update_frontend(profile_name: &str, build_results: &[BuildResult]) -> Result<()> {
     let profile = get_profile_config(profile_name)?;
+    let enabled_challenges = enabled_challenges(profile_name)?;
+
     todo!()
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1,0 +1,37 @@
+use anyhow::{anyhow, bail, Context, Error, Result};
+use itertools::Itertools;
+use simplelog::*;
+
+use crate::clients::{bucket_client, kube_client};
+use crate::cluster_setup as setup;
+use crate::configparser::config::ProfileConfig;
+use crate::configparser::{enabled_challenges, get_config, get_profile_config};
+
+/// Render challenge manifest templates and apply to cluster
+pub async fn deploy_challenges(profile_name: &str) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
+
+    todo!()
+}
+
+/// Upload files to frontend asset bucket
+/// Returns urls of upload files.
+pub async fn upload_assets(profile_name: &str) -> Result<Vec<String>> {
+    let profile = get_profile_config(profile_name)?;
+    let enabled_challenges = enabled_challenges(profile_name)?;
+
+    let bucket = bucket_client(&profile.s3)?;
+
+    for chal in enabled_challenges {}
+
+    todo!()
+
+    // TODO: should uploaded URLs be a (generated) part of the challenge config
+    // struct?
+}
+
+/// Sync deployed challenges with rCTF frontend
+pub async fn update_frontend(profile_name: &str) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
+    todo!()
+}

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -8,10 +8,13 @@ use crate::builder::BuildResult;
 use crate::clients::{bucket_client, kube_client};
 use crate::cluster_setup as setup;
 use crate::configparser::config::ProfileConfig;
-use crate::configparser::{enabled_challenges, get_config, get_profile_config};
+use crate::configparser::{enabled_challenges, get_config, get_profile_config, ChallengeConfig};
 
 /// Render challenge manifest templates and apply to cluster
-pub async fn deploy_challenges(profile_name: &str, build_results: &[BuildResult]) -> Result<()> {
+pub async fn deploy_challenges(
+    profile_name: &str,
+    build_results: &[(&ChallengeConfig, BuildResult)],
+) -> Result<()> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 
@@ -22,7 +25,7 @@ pub async fn deploy_challenges(profile_name: &str, build_results: &[BuildResult]
 /// Returns urls of upload files.
 pub async fn upload_assets(
     profile_name: &str,
-    build_results: &[BuildResult],
+    build_results: &[(&ChallengeConfig, BuildResult)],
 ) -> Result<Vec<String>> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
@@ -36,7 +39,10 @@ pub async fn upload_assets(
 }
 
 /// Sync deployed challenges with rCTF frontend
-pub async fn update_frontend(profile_name: &str, build_results: &[BuildResult]) -> Result<()> {
+pub async fn update_frontend(
+    profile_name: &str,
+    build_results: &[(&ChallengeConfig, BuildResult)],
+) -> Result<()> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod clients;
 pub mod cluster_setup;
 pub mod commands;
 pub mod configparser;
+pub mod deploy;
 
 #[cfg(test)]
 mod tests;

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -241,27 +241,27 @@ fn challenge_provide() {
                 ProvideConfig {
                     from: None,
                     as_file: None,
-                    include: vec!["foo.txt".to_string()]
+                    include: vec!["foo.txt".into()]
                 },
                 ProvideConfig {
                     from: None,
                     as_file: None,
-                    include: vec!["bar.txt".to_string(), "baz.txt".to_string()]
+                    include: vec!["bar.txt".into(), "baz.txt".into()]
                 },
                 ProvideConfig {
                     from: None,
-                    as_file: Some("stuff.zip".to_string()),
-                    include: vec!["ducks".to_string(), "beavers".to_string()]
+                    as_file: Some("stuff.zip".into()),
+                    include: vec!["ducks".into(), "beavers".into()]
                 },
                 ProvideConfig {
-                    from: Some("container".to_string()),
+                    from: Some("container".into()),
                     as_file: None,
-                    include: vec!["/foo/bar".to_string()]
+                    include: vec!["/foo/bar".into()]
                 },
                 ProvideConfig {
                     from: Some("container".to_string()),
-                    as_file: Some("shells.zip".to_string()),
-                    include: vec!["/usr/bin/bash".to_string(), "/usr/bin/zsh".to_string()]
+                    as_file: Some("shells.zip".into()),
+                    include: vec!["/usr/bin/bash".into(), "/usr/bin/zsh".into()]
                 }
             ],
         );

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -88,9 +88,9 @@ fn challenge_two_levels() {
                 category: "foo".to_string(),
                 directory: PathBuf::from("foo/test"),
 
-                flag: FlagType::Text(FileText {
+                flag: FlagType::Text {
                     text: "test{it-works}".to_string()
-                }),
+                },
 
                 provide: vec![],
                 pods: vec![],
@@ -212,9 +212,13 @@ fn challenge_provide() {
 
             provide:
                 - foo.txt
+
                 - include:
                     - bar.txt
                     - baz.txt
+
+                - as: oranges
+                  include: apples
 
                 - as: stuff.zip
                   include:
@@ -224,6 +228,11 @@ fn challenge_provide() {
                 - from: container
                   include:
                     - /foo/bar
+
+                - from: container
+                  as: pears
+                  include:
+                    - /usr/lib/peaches
 
                 - from: container
                   as: shells.zip
@@ -238,30 +247,33 @@ fn challenge_provide() {
         assert_eq!(
             chals[0].provide,
             vec![
-                ProvideConfig {
-                    from: None,
-                    as_file: None,
-                    include: vec!["foo.txt".into()]
+                ProvideConfig::FromRepo {
+                    files: vec!["foo.txt".into()]
                 },
-                ProvideConfig {
-                    from: None,
-                    as_file: None,
-                    include: vec!["bar.txt".into(), "baz.txt".into()]
+                ProvideConfig::FromRepo {
+                    files: vec!["bar.txt".into(), "baz.txt".into()]
                 },
-                ProvideConfig {
-                    from: None,
-                    as_file: Some("stuff.zip".into()),
-                    include: vec!["ducks".into(), "beavers".into()]
+                ProvideConfig::FromRepoRename {
+                    from: "apples".into(),
+                    to: "oranges".into()
                 },
-                ProvideConfig {
-                    from: Some("container".into()),
-                    as_file: None,
-                    include: vec!["/foo/bar".into()]
+                ProvideConfig::FromRepoArchive {
+                    files: vec!["ducks".into(), "beavers".into()],
+                    archive_name: "stuff.zip".into()
                 },
-                ProvideConfig {
-                    from: Some("container".to_string()),
-                    as_file: Some("shells.zip".into()),
-                    include: vec!["/usr/bin/bash".into(), "/usr/bin/zsh".into()]
+                ProvideConfig::FromContainer {
+                    container: "container".to_string(),
+                    files: vec!["/foo/bar".into()]
+                },
+                ProvideConfig::FromContainerRename {
+                    container: "container".to_string(),
+                    from: "/usr/lib/peaches".into(),
+                    to: "pears".into(),
+                },
+                ProvideConfig::FromContainerArchive {
+                    container: "container".to_string(),
+                    files: vec!["/usr/bin/bash".into(), "/usr/bin/zsh".into()],
+                    archive_name: "shells.zip".into(),
                 }
             ],
         );

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -231,8 +231,7 @@ fn challenge_provide() {
 
                 - from: container
                   as: pears
-                  include:
-                    - /usr/lib/peaches
+                  include: /usr/lib/peaches
 
                 - from: container
                   as: shells.zip

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -22,9 +22,9 @@ points:
 deploy:
   # control challenge deployment status explicitly per environment/profile
   testing:
-    misc/garf: true
+    # misc/garf: true
     pwn/notsh: true
-    web/bar: true
+    # web/bar: true
 
 profiles:
   # configure per-environment credentials etc


### PR DESCRIPTION
This adds an initial skeleton for the `deploy` command:

- empty methods for component parts of `deploy`
- checks that charts from `cluster-setup` are deployed

Additionally, this refactors part of the `build` command asset handling in 
order to get a full list of required asset files and container tags that will 
be needed for templating/rendering/frontend.
