### PR TITLE
Fix problems from async build process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "duct",
+ "fastrand",
  "figment",
  "fully_pub",
  "futures",
@@ -715,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 ] }
 minijinja = "2.6.0"
 duct = "0.13.7"
+fastrand = "2.3.0"
 
 
 [dev-dependencies]

--- a/src/builder/artifacts.rs
+++ b/src/builder/artifacts.rs
@@ -176,7 +176,6 @@ async fn extract_rename(
 async fn extract_archive(
     chal: &ChallengeConfig,
     container: &docker::ContainerInfo,
-    // files: &Vec<PathBuf>,
     files: &[PathBuf],
     archive_name: &Path,
 ) -> Result<Vec<PathBuf>> {
@@ -203,7 +202,7 @@ async fn extract_archive(
     // archive_name already has the chal dir prepended
     zip_files(archive_name, &copied_files)?;
 
-    Ok(vec![chal.directory.join(archive_name)])
+    Ok(vec![archive_name.to_path_buf()])
 }
 
 /// Add multiple local `files` to a zipfile at `zip_name`

--- a/src/builder/artifacts.rs
+++ b/src/builder/artifacts.rs
@@ -14,7 +14,6 @@ use crate::clients::docker;
 use crate::configparser::challenge::{ChallengeConfig, ProvideConfig};
 
 /// extract assets from provide config and possible container to challenge directory, return file path(s) extracted
-#[tokio::main(flavor = "current_thread")] // make this a sync function
 pub async fn extract_asset(
     chal: &ChallengeConfig,
     provide: &ProvideConfig,

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -83,7 +83,6 @@ pub async fn build_image(context: &Path, options: &BuildObject, tag: &str) -> Re
     Ok(tag.to_string())
 }
 
-// #[tokio::main(flavor = "current_thread")] // make this a sync function
 pub async fn push_image(image_tag: &str, creds: &UserPass) -> Result<String> {
     info!("pushing image {image_tag:?} to registry");
     let client = docker().await?;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -138,7 +138,7 @@ async fn build_challenge(
 
         // extract each challenge provide entry
         // this handles both local files and from build containers
-        let extracted_files = chal
+        built.assets = chal
             .provide
             .iter()
             .map(|p| async {
@@ -152,7 +152,11 @@ async fn build_challenge(
                     })
             })
             .try_join_all()
-            .await?;
+            .await?
+            // flatten to single vec of all paths
+            .into_iter()
+            .flatten()
+            .collect_vec();
 
         info!("extracted artifacts: {:?}", built.assets);
     }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{anyhow, Context, Error, Result};
 use bollard::image::BuildImageOptions;
-use futures::future::try_join_all;
 use futures::stream::{FuturesOrdered, Iter};
 use itertools::Itertools;
 use simplelog::*;
@@ -16,6 +15,7 @@ use crate::configparser::challenge::{
     BuildObject, ChallengeConfig, ImageSource::*, Pod, ProvideConfig,
 };
 use crate::configparser::{enabled_challenges, get_config};
+use crate::utils::TryJoinAll;
 
 pub mod artifacts;
 pub mod docker;
@@ -52,16 +52,15 @@ pub async fn build_challenges(
     push: bool,
     extract_artifacts: bool,
 ) -> Result<Vec<(&ChallengeConfig, BuildResult)>> {
-    try_join_all(
-        enabled_challenges(profile_name)?
-            .into_iter()
-            .map(|chal| async move {
-                build_challenge(profile_name, chal, push, extract_artifacts)
-                    .await
-                    .map(|r| (chal, r))
-            }),
-    )
-    .await
+    enabled_challenges(profile_name)?
+        .into_iter()
+        .map(|chal| async move {
+            build_challenge(profile_name, chal, push, extract_artifacts)
+                .await
+                .map(|r| (chal, r))
+        })
+        .try_join_all()
+        .await
 }
 
 /// Build all images from given challenge, optionally pushing image or extracting artifacts
@@ -79,28 +78,32 @@ async fn build_challenge(
         assets: vec![],
     };
 
-    built.tags = try_join_all(chal.pods.iter().map(|p| async {
-        match &p.image_source {
-            Image(tag) => Ok(TagWithSource::Upstream(tag.to_string())),
-            // build any pods that need building
-            Build(build) => {
-                let tag = chal.container_tag_for_pod(profile_name, &p.name)?;
+    built.tags = chal
+        .pods
+        .iter()
+        .map(|p| async {
+            match &p.image_source {
+                Image(tag) => Ok(TagWithSource::Upstream(tag.to_string())),
+                // build any pods that need building
+                Build(build) => {
+                    let tag = chal.container_tag_for_pod(profile_name, &p.name)?;
 
-                let res = docker::build_image(&chal.directory, build, &tag)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "error building image {} for chal {}",
-                            p.name,
-                            chal.directory.to_string_lossy()
-                        )
-                    });
-                // map result tag string into enum
-                res.map(TagWithSource::Built)
+                    let res = docker::build_image(&chal.directory, build, &tag)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "error building image {} for chal {}",
+                                p.name,
+                                chal.directory.to_string_lossy()
+                            )
+                        });
+                    // map result tag string into enum
+                    res.map(TagWithSource::Built)
+                }
             }
-        }
-    }))
-    .await?;
+        })
+        .try_join_all()
+        .await?;
 
     if push {
         // only need to push tags we actually built
@@ -119,12 +122,15 @@ async fn build_challenge(
             chal.directory
         );
 
-        try_join_all(tags_to_push.iter().map(|tag| async move {
-            docker::push_image(tag, &config.registry.build)
-                .await
-                .with_context(|| format!("error pushing image {tag}"))
-        }))
-        .await?;
+        tags_to_push
+            .iter()
+            .map(|tag| async move {
+                docker::push_image(tag, &config.registry.build)
+                    .await
+                    .with_context(|| format!("error pushing image {tag}"))
+            })
+            .try_join_all()
+            .await?;
     }
 
     if extract_artifacts {
@@ -132,17 +138,21 @@ async fn build_challenge(
 
         // extract each challenge provide entry
         // this handles both local files and from build containers
-        let extracted_files = try_join_all(chal.provide.iter().map(|p| async {
-            artifacts::extract_asset(chal, p, profile_name)
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to extract build artifacts for chal {:?}",
-                        chal.directory,
-                    )
-                })
-        }))
-        .await?;
+        let extracted_files = chal
+            .provide
+            .iter()
+            .map(|p| async {
+                artifacts::extract_asset(chal, p, profile_name)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to extract build artifacts for chal {:?}",
+                            chal.directory,
+                        )
+                    })
+            })
+            .try_join_all()
+            .await?;
 
         info!("extracted artifacts: {:?}", built.assets);
     }

--- a/src/deploy/s3.rs
+++ b/src/deploy/s3.rs
@@ -9,6 +9,7 @@ use crate::builder::BuildResult;
 use crate::clients::bucket_client;
 use crate::configparser::config::ProfileConfig;
 use crate::configparser::{enabled_challenges, get_config, get_profile_config, ChallengeConfig};
+use crate::utils::TryJoinAll;
 
 /// Upload files to frontend asset bucket
 /// Returns urls of upload files.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cluster_setup;
 pub mod commands;
 pub mod configparser;
 pub mod deploy;
+pub mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,28 @@
+use futures::{future::try_join_all, TryFuture};
+
+/// Helper trait for `Iterator` to add futures::try_await_all() as chain method.
+///
+/// The same as wrapping it in `try_join_all(...).await`, but as a chained
+/// method instead for cleaner readability.
+#[allow(async_fn_in_trait)]
+pub trait TryJoinAll: IntoIterator
+where
+    Self::Item: TryFuture,
+{
+    async fn try_join_all(
+        self,
+    ) -> Result<Vec<<Self::Item as TryFuture>::Ok>, <Self::Item as TryFuture>::Error>;
+}
+
+impl<I> TryJoinAll for I
+where
+    I: IntoIterator,
+    I::Item: TryFuture,
+{
+    /// futures::try_join_all() as a iterator chain method
+    async fn try_join_all(
+        self,
+    ) -> Result<Vec<<Self::Item as TryFuture>::Ok>, <Self::Item as TryFuture>::Error> {
+        try_join_all(self).await
+    }
+}

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -22,9 +22,9 @@ points:
 deploy:
   # control challenge deployment status explicitly per environment/profile
   testing:
-    # misc/garf: true
+    misc/garf: true
     pwn/notsh: true
-    # web/bar: true
+    web/bar: true
 
 profiles:
   # configure per-environment credentials etc


### PR DESCRIPTION
The `deploy` command needs to call `build`, and this was causing problems with nested Tokio runtimes. This fixes the problem by making the last bits of the build process (artifact extraction) properly async instead of blocking with `#[tokio::main]`. 

This exposed a couple other problems from running artifacts in 'parallel'; asset containers can have name collisions. This adds a new dependency `fastrand` to create a discriminator to prevent collisions. (Rust does not have rand generation in the stable stdlib yet.)

Additionally, I added an `Iterator` trait to use `futures::try_join_all()` as a chained method instead of a wrapper. This makes awaiting many futures cleaner to follow.