### PR TITLE
S3 asset upload for deploy command

### DIFF
--- a/src/access_handlers/docker.rs
+++ b/src/access_handlers/docker.rs
@@ -30,12 +30,12 @@ pub async fn check(profile_name: &str) -> Result<()> {
     debug!("will push test image to {}", test_image);
 
     // push alpine image with build credentials
-    check_build_credentials(&client, &test_image)
+    check_build_credentials(client, &test_image)
         .await
         .with_context(|| "Could not push images to registry (bad build credentials?)")?;
 
     // try pulling that image with cluster credentials
-    check_cluster_credentials(&client, &test_image)
+    check_cluster_credentials(client, &test_image)
         .await
         .with_context(|| "Could not pull images from registry (bad cluster credentials?)")?;
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -48,14 +48,14 @@ pub async fn run(profile_name: &str, no_build: &bool, _dry_run: &bool) {
     }
 
     // B)
-    info!("deploying challenges...");
+    info!("uploading assets...");
     if let Err(e) = deploy::s3::upload_assets(profile_name, &build_results).await {
         error!("{e:?}");
         exit(1);
     }
 
     // A)
-    info!("deploying challenges...");
+    info!("updating frontend...");
     if let Err(e) = deploy::frontend::update_frontend(profile_name, &build_results).await {
         error!("{e:?}");
         exit(1);

--- a/src/deploy/s3.rs
+++ b/src/deploy/s3.rs
@@ -33,7 +33,7 @@ pub async fn upload_assets(
         .map(|(chal, result)| async move {
             // upload all files for a specific challenge
 
-            debug!("uploading assets for chal {:?}", chal.directory);
+            info!("  for chal {:?}...", chal.directory);
 
             let uploaded = result
                 .assets


### PR DESCRIPTION
Implements the asset file upload portion of the `deploy` command.

Asset files are uploaded to `<the bucket>/assets/${CHAL/SLUG}/${FILENAME}` (e.g. `/assets/misc/foo/things.zip`)

Depends on #38 and includes its commits.