### PR TITLE
Replace `simplelog` with `tracing` and `tracing-subscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,8 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "void",
  "zip",
 ]
@@ -1642,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1777,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1835,6 +1862,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paris"
@@ -2085,8 +2118,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2097,8 +2139,14 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2555,6 +2603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,9 +2999,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2944,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2955,11 +3022,41 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3053,6 +3150,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,6 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "duct",
- "fastrand",
  "figment",
  "fully_pub",
  "futures",
@@ -287,7 +286,6 @@ dependencies = [
  "serde",
  "serde_nested_with",
  "serde_yml",
- "simplelog",
  "tar",
  "tempfile",
  "tokio",
@@ -1805,15 +1803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,12 +1857,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "paris"
-version = "1.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fecab3723493c7851f292cb060f3ee1c42f19b8d749345d0d7eaf3fd19aa62d"
 
 [[package]]
 name = "parking"
@@ -2643,18 +2626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "paris",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,15 +2737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,9 +2794,7 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -3263,15 +3223,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "minijinja",
+ "owo-colors",
  "pretty_assertions",
  "rust-s3",
  "serde",
@@ -1846,6 +1847,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,6 @@ dependencies = [
  "anyhow",
  "bollard",
  "clap",
- "clap-verbosity-flag",
  "duct",
  "figment",
  "fully_pub",
@@ -408,16 +407,6 @@ checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
-]
-
-[[package]]
-name = "clap-verbosity-flag"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e099138e1807662ff75e2cebe4ae2287add879245574489f9b1588eb5e5564ed"
-dependencies = [
- "clap",
- "log",
 ]
 
 [[package]]
@@ -3007,6 +2996,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "bollard",
  "clap",
  "duct",
+ "fastrand",
  "figment",
  "fully_pub",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["unicode", "env", "derive"] }
-clap-verbosity-flag = "2.2.0"
 itertools = "0.12.1"
 glob = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yml = "0.0.12"
 serde_nested_with = "0.2.5"
 tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter"] }
 fully_pub = "0.1.4"
 void = "1"
 futures = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ glob = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yml = "0.0.12"
 serde_nested_with = "0.2.5"
-simplelog = { version = "0.12.2", features = ["paris"] }
+tracing = { version = "0.1.41", features = ["attributes"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 fully_pub = "0.1.4"
 void = "1"
 futures = "0.3.30"
@@ -35,9 +36,6 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 ] }
 minijinja = { version = "2.6.0", features = ["json"] }
 duct = "0.13.7"
-fastrand = "2.3.0"
-tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 ] }
 minijinja = { version = "2.6.0", features = ["json"] }
 duct = "0.13.7"
+fastrand = "2.3.0"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ glob = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yml = "0.0.12"
 serde_nested_with = "0.2.5"
-tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter"] }
 fully_pub = "0.1.4"
 void = "1"
 futures = "0.3.30"
 figment = { version = "0.10.19", features = ["env", "yaml", "test"] }
 zip = { version = "2.2.2", default-features = false, features = ["deflate"] }
+
+# tracing
+tracing = { version = "0.1.41", features = ["attributes"] }
+tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter"] }
+owo-colors = "4.2.0"
 
 # kubernetes:
 kube = { version = "0.99.0", features = ["runtime", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 minijinja = { version = "2.6.0", features = ["json"] }
 duct = "0.13.7"
 fastrand = "2.3.0"
+tracing = { version = "0.1.41", features = ["attributes"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 
 [dev-dependencies]

--- a/src/access_handlers/docker.rs
+++ b/src/access_handlers/docker.rs
@@ -6,8 +6,8 @@ use bollard::{
 };
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
-use simplelog::*;
 use tokio;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::docker;
 use crate::configparser::{get_config, get_profile_config};

--- a/src/access_handlers/kube.rs
+++ b/src/access_handlers/kube.rs
@@ -4,8 +4,8 @@ use k8s_openapi::api::{
 };
 use k8s_openapi::serde_json::{from_value, json, to_string};
 use kube;
-use simplelog::*;
 use tokio;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::kube_client;
 use crate::configparser::{config, get_config, get_profile_config};

--- a/src/access_handlers/s3.rs
+++ b/src/access_handlers/s3.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Context, Error, Result};
 use s3;
-use simplelog::*;
 use tokio;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::{bucket_client, bucket_client_anonymous};
 use crate::configparser::{

--- a/src/builder/artifacts.rs
+++ b/src/builder/artifacts.rs
@@ -1,12 +1,12 @@
 use anyhow::{anyhow, Context, Error, Result};
 use futures::FutureExt;
 use itertools::Itertools;
-use simplelog::{debug, trace};
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::iter::repeat_with;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir_in;
+use tracing::{debug, error, info, trace, warn};
 use zip;
 
 use crate::builder::docker;

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -8,6 +8,7 @@ use bollard::image::{BuildImageOptions, PushImageOptions};
 use bollard::Docker;
 use core::fmt;
 use futures::{StreamExt, TryStreamExt};
+use owo_colors::OwoColorize;
 use std::fs::File;
 use std::io::{Seek, Write};
 use std::path::PathBuf;
@@ -70,10 +71,10 @@ pub async fn build_image(context: &Path, options: &BuildObject, tag: &str) -> Re
 
                 if let Some(log) = msg.stream {
                     info!(
-                        "building {}: <bright-black>{}</>",
+                        "building {}: {}",
                         context.to_string_lossy(),
                         // tag,
-                        log.trim()
+                        log.trim().bright_black(),
                     )
                 }
             }

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -8,7 +8,6 @@ use bollard::image::{BuildImageOptions, PushImageOptions};
 use bollard::Docker;
 use core::fmt;
 use futures::{StreamExt, TryStreamExt};
-use simplelog::*;
 use std::fs::File;
 use std::io::{Seek, Write};
 use std::path::PathBuf;
@@ -18,6 +17,7 @@ use std::{io::Read, path::Path};
 use tar;
 use tempfile::Builder;
 use tokio;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::docker;
 use crate::configparser::challenge::BuildObject;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -5,11 +5,11 @@ use anyhow::{anyhow, Context, Error, Result};
 use bollard::image::BuildImageOptions;
 use futures::stream::{FuturesOrdered, Iter};
 use itertools::Itertools;
-use simplelog::*;
 use std::default;
 use std::fmt::Pointer;
 use std::iter::zip;
 use std::path::{Path, PathBuf};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::configparser::challenge::{
     BuildObject, ChallengeConfig, ImageSource::*, Pod, ProvideConfig,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,12 @@
 use clap::{Parser, Subcommand};
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 
 #[derive(Parser, Debug)]
 /// Deployment manager for rCTF/beaverCTF challenges deployed on Kubernetes.
 pub struct Cli {
-    #[command(flatten)]
-    pub verbose: Verbosity<InfoLevel>,
+    /// Increase output verbosity. One usage increases slightly. Two increases significantly. Three or
+    /// more maximize output.
+    #[arg(short = 'v', action = clap::ArgAction::Count, global = true)]
+    pub verbosity: u8,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -18,7 +18,7 @@ use kube::{
     runtime::{conditions, wait::await_condition},
 };
 use s3;
-use simplelog::*;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::configparser::config;
 

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -14,6 +14,7 @@ use kube::api::{DynamicObject, Patch, PatchParams};
 use kube::runtime::WatchStreamExt;
 use kube::{Api, ResourceExt};
 use minijinja;
+use owo_colors::OwoColorize;
 use serde;
 use serde_yml;
 use tempfile;
@@ -161,7 +162,9 @@ fn install_helm_chart(
 
     for item in lines {
         match item {
-            Ok(line) => debug!("helm: <bright-black>{line}</>"),
+            Ok(line) => {
+                debug!("helm: {}", line.bright_black());
+            }
             Err(e) => return Err(e.into()),
         }
     }

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -16,8 +16,8 @@ use kube::{Api, ResourceExt};
 use minijinja;
 use serde;
 use serde_yml;
-use simplelog::*;
 use tempfile;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::{apply_manifest_yaml, kube_client};
 use crate::configparser::{config, get_config, get_profile_config};

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
-use simplelog::*;
 use std::process::exit;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::build_challenges;
 use crate::configparser::{get_config, get_profile_config};

--- a/src/commands/check_access.rs
+++ b/src/commands/check_access.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Error, Result};
 use itertools::Itertools;
-use simplelog::*;
 use std::process::exit;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::access_handlers as access;
 use crate::configparser::{get_config, get_profile_config};

--- a/src/commands/cluster_setup.rs
+++ b/src/commands/cluster_setup.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Error, Result};
 use itertools::Itertools;
-use simplelog::*;
 use std::process::exit;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::cluster_setup as setup;
 use crate::configparser::{get_config, get_profile_config};

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
-use simplelog::*;
 use std::process::exit;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::build_challenges;
 use crate::configparser::{get_config, get_profile_config};

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,6 +1,6 @@
-use simplelog::*;
 use std::path::Path;
 use std::process::exit;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::configparser::{get_challenges, get_config, get_profile_deploy};
 

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -6,10 +6,10 @@ use glob::glob;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_nested_with::serde_nested;
-use simplelog::*;
 use std::collections::HashMap as Map;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use tracing::{debug, error, info, trace, warn};
 use void::Void;
 
 use crate::builder::image_tag_str;

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -2,9 +2,9 @@ use anyhow::{Context, Result};
 use fully_pub::fully_pub;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use simplelog::*;
 use std::collections::HashMap as Map;
 use std::fs;
+use tracing::{debug, error, info, trace, warn};
 
 use figment::providers::{Env, Format, Yaml};
 use figment::Figment;

--- a/src/configparser/mod.rs
+++ b/src/configparser/mod.rs
@@ -6,9 +6,9 @@ use anyhow::{anyhow, Error, Result};
 pub use challenge::ChallengeConfig; // reexport
 pub use config::UserPass; // reexport
 use itertools::Itertools;
-use simplelog::*;
 use std::path::Path;
 use std::sync::OnceLock;
+use tracing::{debug, error, info, trace, warn};
 
 // todo: replace with std::LazyLock once v1.80 is out?
 pub static CONFIG: OnceLock<config::RcdsConfig> = OnceLock::new();

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
-use simplelog::*;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::BuildResult;
 use crate::configparser::config::ProfileConfig;

--- a/src/deploy/kubernetes/mod.rs
+++ b/src/deploy/kubernetes/mod.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
 use minijinja;
-use simplelog::*;
 use tokio::time::timeout;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::BuildResult;
 use crate::clients::{apply_manifest_yaml, kube_client, wait_for_status};

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -6,8 +6,8 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use itertools::Itertools;
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::ListParams;
-use simplelog::*;
 use std::env::current_exe;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::clients::kube_client;
 use crate::cluster_setup;

--- a/src/deploy/s3.rs
+++ b/src/deploy/s3.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use futures::future::try_join_all;
 use itertools::Itertools;
 use s3::Bucket;
-use simplelog::*;
 use tokio;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::BuildResult;
 use crate::clients::bucket_client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,43 @@
 use beavercds_ng::commands;
 use clap::Parser;
 use tracing::{trace, Level};
-use tracing_subscriber::{fmt::time, EnvFilter};
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, time},
+    EnvFilter,
+};
 
 mod cli;
 
 fn main() {
     let cli = cli::Cli::parse();
 
-    // number of 'v' flags influences our crate's log level, all other log levels, and whether or
-    // not we display the span stack, respectively
-    let (brcds_level, dep_level, display_spans) = match cli.verbosity {
-        0 => (Level::INFO, Level::WARN, false),
-        1 => (Level::DEBUG, Level::INFO, false),
-        2 => (Level::TRACE, Level::DEBUG, true),
-        _ => (Level::TRACE, Level::TRACE, true),
+    // number of 'v' flags influences our crate's log level and all other log levels separately
+    let (brcds_level, dep_level) = match cli.verbosity {
+        0 => (Level::INFO, Level::WARN),
+        1 => (Level::DEBUG, Level::INFO),
+        2 => (Level::TRACE, Level::DEBUG),
+        _ => (Level::TRACE, Level::TRACE),
+    };
+    // this is our threshold for a lot more (but far from all) information
+    let (extra_toggles, timestr, events) = if cli.verbosity >= 2 {
+        (true, "%H:%M:%S%.f", FmtSpan::NEW | FmtSpan::CLOSE)
+    } else {
+        (false, "%H:%M:%S", FmtSpan::NONE)
     };
 
     // Use RUST_LOG env variable to set log levels if it's set
     // Otherwise we use the above levels. Span-stack display always influenced by -v
-    let timer = time::ChronoLocal::new("%H:%M:%S".to_owned());
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             format!("{}={brcds_level},{dep_level}", env!("CARGO_CRATE_NAME")).into()
         }))
-        .with_timer(timer)
-        .with_target(display_spans)
+        .with_timer(time::ChronoLocal::new(timestr.to_string()))
+        .with_target(extra_toggles)
+        .with_thread_ids(extra_toggles)
+        .with_span_events(events)
         .init();
 
     trace!("args: {:?}", cli);
-
     // dispatch commands
     match &cli.command {
         cli::Commands::Validate => commands::validate::run(),


### PR DESCRIPTION
As requested in #33 
I tried to (roughly) replicate the current logging output using the `fmt` subscriber. Lots of stuff can be twiddled with format and information though. My thought on the new way to set log levels is that log levels below INFO on deps are probably only useful during development  (where setting `RUST_LOG` is not a big deal) - so I use the current verbosity flag to just change this crate's log level.

Other ideas:
- More layers can be added to expose events to outside *things* like Tokio console, outside log aggregators, etc.
- Spans can be used to give more useful context to work units. [The macro](https://docs.rs/tracing/latest/tracing/attr.instrument.html) is recommended to avoid footguns.