### PR TITLE
Add config option for custom image tag format

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -20,14 +20,6 @@ use crate::utils::TryJoinAll;
 pub mod artifacts;
 pub mod docker;
 
-// define tag format as reusable macro
-macro_rules! image_tag_str {
-    () => {
-        "{registry}/{challenge}-{container}:{profile}"
-    };
-}
-pub(super) use image_tag_str;
-
 /// Information about all of a challenge's build artifacts.
 #[derive(Debug)]
 pub struct BuildResult {

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -345,3 +345,19 @@ pub async fn wait_for_status(client: &kube::Client, object: &DynamicObject) -> R
 
     Ok(())
 }
+
+//
+// Minijinja strict rendering with error
+//
+
+/// Similar to minijinja.render!(), but return Error if any undefined values.
+pub fn render_strict(template: &str, context: minijinja::Value) -> Result<String> {
+    let mut strict_env = minijinja::Environment::new();
+    // error on any undefined template variables
+    strict_env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+
+    let r = strict_env
+        .render_str(template, context)
+        .context(format!("could not render template {:?}", template))?;
+    Ok(r)
+}

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -157,7 +157,7 @@ impl ChallengeConfig {
             ImageSource::Build(b) => Ok(render!(
                 &get_config()?.registry.tag_format,
                 domain => config.registry.domain,
-                challenge => self.name,
+                challenge => self.slugify(),
                 container => pod.name,
                 profile => profile_name
             )),

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -60,9 +60,40 @@ struct RcdsConfig {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[fully_pub]
 struct Registry {
+    /// Registry base url used to build part of the full image string.
+    ///
+    /// Example: `domain: "registry.io/myctf"`
     domain: String,
+
+    /// Image tag format string. Useful if the registry forces a single
+    /// container repository (AWS...)
+    ///
+    /// Default: `"{domain}/{challenge}-{container}:{profile}"`
+    ///
+    /// Available fields:
+    /// - `domain`: the domain config field above; the repository base URL
+    /// - `challenge`: challenge name, slugified
+    /// - `container`: name of the specific pod in the challenge this image is for
+    /// - `profile`: the current deployment profile, for isolating images between environments
+    ///
+    /// Example:
+    ///
+    /// For challenge `pwn/notsh`, chal pod container `main`, profile `prod`, and the example domain:
+    /// ```py
+    /// "{domain}/{challenge}-{container}:{profile}" --> "registry.io/myctf/pwn-notsh-main:prod"
+    ///
+    /// "{domain}:{challenge}-{container}" --> "registry.io/myctf:pwn-notsh-main"
+    /// ```
+    #[serde(default = "default_tag_format")]
+    tag_format: String,
+
+    /// Container registry login for pushing images during build/deploy
     build: UserPass,
+    /// Container registry login for pulling images in cluster. Can and should be read-only.
     cluster: UserPass,
+}
+fn default_tag_format() -> String {
+    "{domain}/{challenge}-{container}:{profile}".to_string()
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -66,9 +66,11 @@ struct Registry {
     domain: String,
 
     /// Image tag format string. Useful if the registry forces a single
-    /// container repository (AWS...)
+    /// container repository. (AWS...)
     ///
-    /// Default: `"{domain}/{challenge}-{container}:{profile}"`
+    /// Format: Jinja-style double-braces around field name (`{{ field_name }}`)
+    ///
+    /// Default: `"{{domain}}/{{challenge}}-{{container}}:{{profile}}"`
     ///
     /// Available fields:
     /// - `domain`: the domain config field above; the repository base URL
@@ -80,9 +82,9 @@ struct Registry {
     ///
     /// For challenge `pwn/notsh`, chal pod container `main`, profile `prod`, and the example domain:
     /// ```py
-    /// "{domain}/{challenge}-{container}:{profile}" --> "registry.io/myctf/pwn-notsh-main:prod"
+    /// the default --> "registry.io/myctf/pwn-notsh-main:prod"
     ///
-    /// "{domain}:{challenge}-{container}" --> "registry.io/myctf:pwn-notsh-main"
+    /// "{{domain}}:{{challenge}}-{{container}}" --> "registry.io/myctf:pwn-notsh-main"
     /// ```
     #[serde(default = "default_tag_format")]
     tag_format: String,
@@ -93,7 +95,7 @@ struct Registry {
     cluster: UserPass,
 }
 fn default_tag_format() -> String {
-    "{domain}/{challenge}-{container}:{profile}".to_string()
+    "{{domain}}/{{challenge}}-{{container}}:{{profile}}".to_string()
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -18,6 +18,7 @@ pub fn parse() -> Result<RcdsConfig> {
         // keys by undoing the s/_/./ that the figment::split() did.
         var.to_string()
             .to_lowercase()
+            .replace("registry.tag.format", "registry.tag_format")
             .replace("frontend.", "frontend_")
             .replace("challenges.", "challenges_")
             .replace("s3.access.", "s3.access_")

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -66,12 +66,17 @@ struct Registry {
     /// Example: `domain: "registry.io/myctf"`
     domain: String,
 
-    /// Image tag format string. Useful if the registry forces a single
-    /// container repository. (AWS...)
+    /// Container image tag format for challenge images.
     ///
-    /// Format: Jinja-style double-braces around field name (`{{ field_name }}`)
+    /// Format:
+    /// Jinja-style double-braces around field name (`{{ field_name }}`)
     ///
-    /// Default: `"{{domain}}/{{challenge}}-{{container}}:{{profile}}"`
+    /// Default, works for most registries (self-hosted, GCP, DigitalOcean, ...):
+    /// `"{{domain}}/{{challenge}}-{{container}}:{{profile}}"`
+    ///
+    /// For registries like AWS that make it hard to create individual repositories,
+    /// keep all the challenge info in the tag:
+    /// `"{{domain}}:{{challenge}}-{{container}}-{{profile}}"`
     ///
     /// Available fields:
     /// - `domain`: the domain config field above; the repository base URL

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -2,6 +2,7 @@ flag_regex: dam{[a-zA-Z...]}
 
 registry:
   domain: localhost:5000/damctf
+  tag_format: "{{domain}}/{{challenge}}/{{container}}:{{profile}}"
   # or environment vars e.g. BEAVERCDS_REGISTRY_BUILD_USER / etc
   build:
     user: admin


### PR DESCRIPTION
Instead of hardcoding the expected challenge container image tag format, expose that to the user with a new config option `registry.tag_format`.

Some registries (AWS....) make it difficult to create separate image repositories for each different container. This lets that user change the tag format that beavercds is using, e.g. to something that uses many tags inside one repository.