### PR TITLE
Changes to make DamCTF work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "base64ct",
  "bollard",
  "clap",
+ "docker_credential",
  "duct",
  "fastrand",
  "figment",
@@ -632,6 +633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2477,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,10 +264,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
 name = "beavercds-ng"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64ct",
  "bollard",
  "clap",
  "duct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rust-s3 = { version = "0.35.1", default-features = false, features = [
 minijinja = { version = "2.6.0", features = ["json"] }
 duct = "0.13.7"
 fastrand = "2.3.0"
+base64ct = { version = "1.7.3", features = ["alloc"] }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ minijinja = { version = "2.6.0", features = ["json"] }
 duct = "0.13.7"
 fastrand = "2.3.0"
 base64ct = { version = "1.7.3", features = ["alloc"] }
+docker_credential = "1.3.2"
 
 
 [dev-dependencies]

--- a/docs/for-challenge-authors.md
+++ b/docs/for-challenge-authors.md
@@ -102,7 +102,8 @@ Files to give to players as downloads in frontend.
 
 These can be from the challenge folder in the repository, or from the
 challenge's built container. These can also be zipped together into one file, or
-uploaded separately.
+uploaded separately. These need to be files, directories or globs are not (yet)
+supported.
 
 This can be omitted if there are no files provided.
 

--- a/docs/for-challenge-authors.md
+++ b/docs/for-challenge-authors.md
@@ -1,0 +1,198 @@
+# How to write beaverCDS challenge.yaml config
+
+tldr: see [the TCP example](#full-tcp-example) or [the web example](#full-http-example).
+
+### Metadata
+
+Self explanatory.
+
+```yaml
+name: yet another pyjail
+author: somebody, John Author
+```
+
+### Description
+
+Challenge description supports markdown and Jinja-style templating for challenge info.
+The Jinja template fields available are:
+
+| Field name  | Description |
+| ----------- | ----------- |
+| `hostname`  | The hostname or domain for the challenge
+| `port`      | The port that the challenge is listening on
+| `nc`        | Insert the `nc` command to connect to TCP challenges (`nc {{hostname}} {{port}}`)
+| `link`      | Create a Markdown link to the exposed hostname/port
+| `url`       | The URL from `link` without the accompanying Markdown
+| `challenge` | The full challenge.yaml config for this challenge, with subfields
+
+You probably only want `{{ nc }}` or `{{ link }}`.
+
+Example:
+
+```yaml
+description: |
+    Some example challenge. Blah blah blah flavor text.
+
+    In case you missed it, this was written by {{ challenge.author }}
+    and is called {{ challenge.name }}.
+
+    {{ link }}    # -becomes-> [example.chals.thectf.com](https://example.chals.thectf.com)
+    {{ nc }}      # -becomes-> `nc example.chals.thectf.com 12345`
+```
+
+
+### Flag
+
+Read flag from file:
+
+```yaml
+flag:
+  file: ./flag
+```
+
+### Pods
+
+Defines how any container images for this challenge are built and deployed.
+
+The pod `name` is also used for extracting files, see [Providing files to
+users](<for-challenge-authors#Providing files to users>).
+
+`build` works similar to [Docker Compose](https://docs.docker.com/reference/compose-file/build/#illustrative-example),
+either:
+  - a string path to the build context folder
+  - yaml with explicit `context` path, `dockerfile` path within context folder, and `args` build args \
+    (only `context`, `dockerfile`, and `args` are supported for the detailed form)
+
+`ports` controls how the container is exposed. This should be a list of what port the container is listening, and how
+that port should be exposed to players:
+- For TCP challenges, set `expose.tcp` to the subdomain and port: `<subdomain>:<port>`
+- For HTTP challenges, set `expose.http` to the subdomain only: `<subdomain>` \
+  The website domain will automatically be set up with an HTTPS cert.
+
+
+```yaml
+pods:
+  - name: tcp-example
+    build: .
+    replicas: 2
+    ports:
+      - internal: 31337
+        expose:
+          tcp: thechal:30124  # exposed at thechal.<challenges_domain>:30124
+
+  - name: web-example
+    build:
+      context: src/
+      dockerfile: Containerfile
+    replicas: 2
+    ports:
+      - internal: 31337
+        expose:
+          http: webchal  # exposed at https://webchal.<challenges_domain>
+```
+
+
+
+
+This can be omitted if there are no containers for the challenge.
+
+### Providing files to users
+
+Files to give to players as downloads in frontend.
+
+These can be from the challenge folder in the repository, or from the
+challenge's built container. These can also be zipped together into one file, or
+uploaded separately.
+
+This can be omitted if there are no files provided.
+
+```yaml
+provide:
+  # file from the challenge folder in the repo
+  - somefile.txt
+
+  # multiple files from chal_folder/src/, zipped as together.zip
+  - as: together.zip
+    include:
+      - src/file1
+      - src/file2
+      - src/file3
+
+  # extract these files from inside of the container image
+  # for the `main` pod (see previous section)
+  - from: main
+    include:
+      - /chal/notsh
+      - /lib/x86_64-linux-gnu/libc.so.6
+
+  # same as above, but now zipped together
+  - from: main
+    as: notsh.zip
+    include:
+      - /chal/notsh
+      - /lib/x86_64-linux-gnu/libc.so.6
+```
+
+
+
+
+
+# Examples
+
+## Full TCP example
+
+```yaml
+name: notsh
+author: John Author
+description: |-
+  This challenge isn't a shell
+
+  {{ nc }}
+
+provide:
+  - from: main
+    include:
+      - /chal/notsh
+      - /lib/x86_64-linux-gnu/libc.so.6
+
+flag:
+  file: ./flag
+
+pods:
+  - name: main
+    build: .
+    replicas: 2
+    ports:
+      - internal: 31337
+        expose:
+          tcp: 30124
+```
+
+## Full HTTP example
+
+```yaml
+name: bar
+author: somebody
+description: |
+  can you order a drink from the webserver?
+
+  {{ url }}
+
+difficulty: 1
+
+flag:
+  file: ./flag
+
+# no provide: section needed if no files
+
+pods:
+  - name: bar
+    build:
+      context: .
+      dockerfile: Containerfile
+    replicas: 1
+    ports:
+      - internal: 80
+        expose:
+          http: bar # subdomain only
+```

--- a/src/access_handlers/docker.rs
+++ b/src/access_handlers/docker.rs
@@ -10,8 +10,8 @@ use minijinja;
 use tokio;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::clients::{docker, render_strict};
 use crate::configparser::{get_config, get_profile_config};
+use crate::{clients::docker, utils::render_strict};
 
 /// container registry / daemon access checks
 #[tokio::main(flavor = "current_thread")] // make this a sync function

--- a/src/asset_files/challenge_templates/deployment.yaml.j2
+++ b/src/asset_files/challenge_templates/deployment.yaml.j2
@@ -19,6 +19,8 @@ spec:
       labels:
         rctf/part-of: "{{ slug }}-{{ pod.name }}"
     spec:
+      imagePullSecrets:
+        - name: "rcds-{{ slug }}-pull"
       containers:
         - name: "{{ pod.name }}"
           image: "{{ pod_image }}"

--- a/src/asset_files/challenge_templates/deployment.yaml.j2
+++ b/src/asset_files/challenge_templates/deployment.yaml.j2
@@ -21,6 +21,8 @@ spec:
     spec:
       imagePullSecrets:
         - name: "rcds-{{ slug }}-pull"
+      nodeSelector:
+        kubernetes.io/arch: {{ pod.architecture }}
       containers:
         - name: "{{ pod.name }}"
           image: "{{ pod_image }}"

--- a/src/asset_files/challenge_templates/deployment.yaml.j2
+++ b/src/asset_files/challenge_templates/deployment.yaml.j2
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: "{{ pod.name }}"
           image: "{{ pod_image }}"
+          imagePullPolicy: Always
           ports:
             {% for p in pod.ports -%}
             - containerPort: {{ p.internal }}

--- a/src/asset_files/challenge_templates/http.yaml.j2
+++ b/src/asset_files/challenge_templates/http.yaml.j2
@@ -24,6 +24,7 @@ metadata:
   namespace: "rcds-{{ slug }}"
   annotations:
     app.kubernetes.io/managed-by: rcds
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClassName: beavercds
   rules:
@@ -38,8 +39,11 @@ spec:
               name: "rcds-{{ slug }}-{{ pod.name }}-http"
               port:
                 number: {{ p.internal }}
-
-      tls:
-        - hosts: [ "{{ p.expose.http }}.{{ domain }}" ]
-          secretName: "rcds-tls-{{ p.expose.http }}.{{ domain }}"
   {% endfor -%}
+
+  tls:
+    - hosts:
+      {%- for p in http_ports %}
+        - "{{ p.expose.http }}.{{ domain }}"
+      {% endfor -%}
+      secretName: "rcds-tls-{{ slug }}-{{ pod.name }}"

--- a/src/asset_files/challenge_templates/http.yaml.j2
+++ b/src/asset_files/challenge_templates/http.yaml.j2
@@ -38,4 +38,8 @@ spec:
               name: "rcds-{{ slug }}-{{ pod.name }}-http"
               port:
                 number: {{ p.internal }}
+
+      tls:
+        - hosts: [ "{{ p.expose.http }}.{{ domain }}" ]
+          secretName: "rcds-tls-{{ p.expose.http }}.{{ domain }}"
   {% endfor -%}

--- a/src/asset_files/challenge_templates/namespace.yaml.j2
+++ b/src/asset_files/challenge_templates/namespace.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rcds-{{ slug }}
+  name: "rcds-{{ slug }}"
   annotations:
     app.kubernetes.io/managed-by: rcds
     rctf/challenge: "{{ chal.name }}"

--- a/src/asset_files/challenge_templates/pull-secret.yaml.j2
+++ b/src/asset_files/challenge_templates/pull-secret.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: "rcds-{{ slug }}-pull"
+  namespace: "rcds-{{ slug }}"
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "{{ registry_domain }}": {
+          "auth": "{{ creds_b64 }}"
+        }
+      }
+    }

--- a/src/asset_files/challenge_templates/tcp.yaml.j2
+++ b/src/asset_files/challenge_templates/tcp.yaml.j2
@@ -9,6 +9,14 @@ metadata:
     # still use separate domain for these, since exposed LoadBalancer services
     # will all have different ips from each other
     external-dns.alpha.kubernetes.io/hostname: "{{ slug }}.{{ domain }}"
+
+    # aws-specific annotations for lb options
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "true"
+
 spec:
   type: LoadBalancer
   selector:

--- a/src/asset_files/challenge_templates/tcp.yaml.j2
+++ b/src/asset_files/challenge_templates/tcp.yaml.j2
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: rcds
     # still use separate domain for these, since exposed LoadBalancer services
     # will all have different ips from each other
-    external-dns.alpha.kubernetes.io/hostname: "{{ slug }}.{{ domain }}"
+    external-dns.alpha.kubernetes.io/hostname: "{{ chal.name }}.{{ domain }}"
 
     # aws-specific annotations for lb options
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"

--- a/src/asset_files/challenge_templates/tcp.yaml.j2
+++ b/src/asset_files/challenge_templates/tcp.yaml.j2
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: rcds
     # still use separate domain for these, since exposed LoadBalancer services
     # will all have different ips from each other
-    external-dns.alpha.kubernetes.io/hostname: "{{ chal.name }}.{{ domain }}"
+    external-dns.alpha.kubernetes.io/hostname: "{{ name_slug }}.{{ domain }}"
 
     # aws-specific annotations for lb options
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"

--- a/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
+++ b/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
@@ -20,10 +20,8 @@ txtOwnerId: "k8s-external-dns"
 txtPrefix: "k8s-owner."
 
 extraArgs:
-  # ignore any services with internal ips
-  #exclude-target-net: "10.0.0.0/8"
   # special character replacement
-  txt-wildcard-replacement: star
+  - --txt-wildcard-replacement=star
 
 ## Limit external-dns resources
 resources:

--- a/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
+++ b/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
@@ -20,6 +20,8 @@ txtPrefix: "k8s-owner."
 extraArgs:
   # special character replacement
   - --txt-wildcard-replacement=star
+  # use CNAME instead of ALIAS for alb targets
+  - --aws-prefer-cname
 
 ## Limit external-dns resources
 resources:

--- a/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
+++ b/src/asset_files/setup_manifests/external-dns.helm.yaml.j2
@@ -2,8 +2,6 @@
 rbac:
   create: true
 
-{{ provider_credentials }}
-
 # Watch these resources for new DNS records
 sources:
   - service
@@ -32,3 +30,6 @@ resources:
     cpu: 10m
 
 logLevel: debug
+
+# assign last to override any previous values if required
+{{ provider_credentials }}

--- a/src/asset_files/setup_manifests/ingress-nginx.helm.yaml
+++ b/src/asset_files/setup_manifests/ingress-nginx.helm.yaml
@@ -3,6 +3,15 @@ controller:
   ingressClassResource:
     name: beavercds
 
+  # set variety of annotations needed for the cloud providers
+
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "true"
+
 # nginx values for tcp ports will be set separately in other values file
 # this will make it easier for `deploy` to update those values without
 # subsequent calls to `cluster-setup` overwriting changes.

--- a/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
+++ b/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
@@ -4,7 +4,7 @@ metadata:
   name: letsencrypt
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory"
+    server: https://acme-v02.api.letsencrypt.org/directory
     # TODO: use user email?
     email: beavercds-prod@{{ chal_domain }}
     privateKeySecretRef:

--- a/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
+++ b/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
@@ -6,7 +6,7 @@ spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory"
     # TODO: use user email?
-    email: beavercds-prod@example.com
+    email: beavercds-prod@{{ chal_domain }}
     privateKeySecretRef:
       name: letsencrypt-secret
     solvers:
@@ -23,7 +23,7 @@ spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     # TODO: use user email?
-    email: beavercds-staging@example.com
+    email: beavercds-staging@{{ chal_domain }}
     privateKeySecretRef:
       name: letsencrypt-staging-secret
     solvers:

--- a/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
+++ b/src/asset_files/setup_manifests/letsencrypt.issuers.yaml
@@ -12,7 +12,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          ingressClassName: beavercds
 
 ---
 apiVersion: cert-manager.io/v1
@@ -29,4 +29,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          ingressClassName: beavercds

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -29,7 +29,12 @@ pub struct ContainerInfo {
     id: String,
 }
 
-pub async fn build_image(context: &Path, options: &BuildObject, tag: &str) -> Result<String> {
+pub async fn build_image(
+    context: &Path,
+    options: &BuildObject,
+    tag: &str,
+    arch: &str,
+) -> Result<String> {
     trace!("building image in directory {context:?} to tag {tag:?}");
     let client = docker().await?;
 
@@ -38,6 +43,7 @@ pub async fn build_image(context: &Path, options: &BuildObject, tag: &str) -> Re
         buildargs: options.args.clone(),
         t: tag.to_string(),
         forcerm: true,
+        platform: format!("linux/{arch}"),
         ..Default::default()
     };
 

--- a/src/builder/docker.rs
+++ b/src/builder/docker.rs
@@ -20,7 +20,7 @@ use tempfile::Builder;
 use tokio;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::clients::docker;
+use crate::clients::{docker, docker_creds};
 use crate::configparser::challenge::BuildObject;
 use crate::configparser::UserPass;
 
@@ -55,8 +55,12 @@ pub async fn build_image(
         .with_context(|| "could not create image context tarball")?;
     let tarball = tar.into_inner()?;
 
+    // fetch dockerhub creds from ~/.docker/auth.json for pull reasons
+    // if creds fail to fetch, go anonymous
+    let credentials = docker_creds()?;
+
     // send to docker daemon
-    let mut build_stream = client.build_image(build_opts, None, Some(tarball.into()));
+    let mut build_stream = client.build_image(build_opts, Some(credentials), Some(tarball.into()));
 
     // stream output to stdout
     while let Some(item) = build_stream.next().await {

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -80,7 +80,7 @@ async fn build_challenge(
                 Build(build) => {
                     let tag = chal.container_tag_for_pod(profile_name, &p.name)?;
 
-                    let res = docker::build_image(&chal.directory, build, &tag)
+                    let res = docker::build_image(&chal.directory, build, &tag, &p.architecture)
                         .await
                         .with_context(|| {
                             format!(

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -345,19 +345,3 @@ pub async fn wait_for_status(client: &kube::Client, object: &DynamicObject) -> R
 
     Ok(())
 }
-
-//
-// Minijinja strict rendering with error
-//
-
-/// Similar to minijinja.render!(), but return Error if any undefined values.
-pub fn render_strict(template: &str, context: minijinja::Value) -> Result<String> {
-    let mut strict_env = minijinja::Environment::new();
-    // error on any undefined template variables
-    strict_env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
-
-    let r = strict_env
-        .render_str(template, context)
-        .context(format!("could not render template {:?}", template))?;
-    Ok(r)
-}

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -222,7 +222,7 @@ pub async fn apply_manifest_yaml(
     // this manifest has multiple documents (crds, deployment)
     for yaml in multidoc_deserialize(manifest)? {
         let obj: DynamicObject = serde_yml::from_value(yaml)?;
-        debug!(
+        trace!(
             "applying resource {} {}",
             obj.types.clone().unwrap_or_default().kind,
             obj.name_any()

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -111,6 +111,11 @@ fn install_helm_chart(
     namespace: &str,
     values: &str,
 ) -> Result<()> {
+    // make sure `helm` is available to run
+    duct::cmd!("helm", "version")
+        .read()
+        .context("helm binary is not available")?;
+
     // write values to tempfile
     let mut temp_values = tempfile::Builder::new()
         .prefix(release_name)

--- a/src/cluster_setup/mod.rs
+++ b/src/cluster_setup/mod.rs
@@ -40,7 +40,8 @@ pub async fn install_ingress(profile: &config::ProfileConfig) -> Result<()> {
     install_helm_chart(
         profile,
         "ingress-nginx",
-        Some("https://kubernetes.github.io/ingress-nginx"),
+        "https://kubernetes.github.io/ingress-nginx",
+        None,
         "ingress-nginx",
         INGRESS_NAMESPACE,
         VALUES,
@@ -57,7 +58,8 @@ pub async fn install_certmanager(profile: &config::ProfileConfig) -> Result<()> 
     install_helm_chart(
         profile,
         "cert-manager",
-        Some("https://charts.jetstack.io"),
+        "https://charts.jetstack.io",
+        None,
         "cert-manager",
         INGRESS_NAMESPACE,
         VALUES,
@@ -90,7 +92,8 @@ pub async fn install_extdns(profile: &config::ProfileConfig) -> Result<()> {
 
     install_helm_chart(
         profile,
-        "oci://registry-1.docker.io/bitnamicharts/external-dns",
+        "external-dns",
+        "https://kubernetes-sigs.github.io/external-dns",
         None,
         "external-dns",
         INGRESS_NAMESPACE,
@@ -106,7 +109,8 @@ pub async fn install_extdns(profile: &config::ProfileConfig) -> Result<()> {
 fn install_helm_chart(
     profile: &config::ProfileConfig,
     chart: &str,
-    repo: Option<&str>,
+    repo: &str,
+    version: Option<&str>,
     release_name: &str,
     namespace: &str,
     values: &str,
@@ -123,8 +127,8 @@ fn install_helm_chart(
         .tempfile()?;
     temp_values.write_all(values.as_bytes())?;
 
-    let repo_arg = match repo {
-        Some(r) => format!("--repo {r}"),
+    let version_arg = match version {
+        Some(v) => format!("--version {v}"),
         None => "".to_string(),
     };
 
@@ -139,7 +143,7 @@ fn install_helm_chart(
         r#"
         upgrade --install
             {release_name}
-            {chart} {repo_arg}
+            {chart} --repo {repo} {version_arg}
             --namespace {namespace} --create-namespace
             --values {}
             --wait --timeout 1m

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use itertools::Itertools;
 use std::process::exit;
 use tracing::{debug, error, info, trace, warn};
@@ -6,15 +7,12 @@ use crate::builder::build_challenges;
 use crate::configparser::{get_config, get_profile_config};
 
 #[tokio::main(flavor = "current_thread")] // make this a sync function
-pub async fn run(profile_name: &str, push: &bool, extract: &bool) {
+pub async fn run(profile_name: &str, push: &bool, extract: &bool) -> Result<()> {
     info!("building images...");
 
-    let results = match build_challenges(profile_name, *push, *extract).await {
-        Ok(results) => results,
-        Err(e) => {
-            error!("{e:?}");
-            exit(1)
-        }
-    };
+    let results = build_challenges(profile_name, *push, *extract).await?;
+
     info!("images built successfully!");
+
+    Ok(())
 }

--- a/src/commands/check_access.rs
+++ b/src/commands/check_access.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Error, Result};
+use anyhow::{bail, Context, Error, Result};
 use itertools::Itertools;
 use std::process::exit;
 use tracing::{debug, error, info, trace, warn};
@@ -6,7 +6,13 @@ use tracing::{debug, error, info, trace, warn};
 use crate::access_handlers as access;
 use crate::configparser::{get_config, get_profile_config};
 
-pub fn run(profile: &str, kubernetes: &bool, frontend: &bool, registry: &bool, bucket: &bool) {
+pub fn run(
+    profile: &str,
+    kubernetes: &bool,
+    frontend: &bool,
+    registry: &bool,
+    bucket: &bool,
+) -> Result<()> {
     // if user did not give a specific check, check all of them
     let check_all = !kubernetes && !frontend && !registry && !bucket;
 
@@ -36,6 +42,7 @@ pub fn run(profile: &str, kubernetes: &bool, frontend: &bool, registry: &bool, b
     debug!("access results: {results:?}");
 
     // die if there were any errors
+    // TODO: figure out how to return this error directly
     let mut should_exit = false;
     for (profile, result) in results.iter() {
         match result {
@@ -48,8 +55,10 @@ pub fn run(profile: &str, kubernetes: &bool, frontend: &bool, registry: &bool, b
         }
     }
     if should_exit {
-        exit(1);
+        bail!("config validation failed");
     }
+
+    Ok(())
 }
 
 /// checks a single profile (`profile`) for the given accesses

--- a/src/commands/cluster_setup.rs
+++ b/src/commands/cluster_setup.rs
@@ -7,22 +7,15 @@ use crate::cluster_setup as setup;
 use crate::configparser::{get_config, get_profile_config};
 
 #[tokio::main(flavor = "current_thread")] // make this a sync function
-pub async fn run(profile_name: &str) {
+pub async fn run(profile_name: &str) -> Result<()> {
     info!("setting up cluster...");
     let config = get_profile_config(profile_name).unwrap();
 
-    if let Err(e) = setup::install_ingress(config).await {
-        error!("{e:?}");
-        exit(1);
-    }
-    if let Err(e) = setup::install_certmanager(config).await {
-        error!("{e:?}");
-        exit(1);
-    }
-    if let Err(e) = setup::install_extdns(config).await {
-        error!("{e:?}");
-        exit(1);
-    }
+    setup::install_ingress(config).await?;
+    setup::install_certmanager(config).await?;
+    setup::install_extdns(config).await?;
 
-    info!("charts deployed!")
+    info!("charts deployed!");
+
+    Ok(())
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use itertools::Itertools;
 use std::process::exit;
 use tracing::{debug, error, info, trace, warn};
@@ -29,23 +29,9 @@ pub async fn run(profile_name: &str, no_build: &bool, _dry_run: &bool) -> Result
         build_results.iter().map(|b| &b.1).collect_vec()
     );
 
-    // deploy needs to:
-    // A) render kubernetes manifests
-    //    - namespace, deployment, service, ingress
-    //    - upgrade ingress config with new listen ports
-    //
-    // B) upload asset files to bucket
-    //
-    // C) update frontend with new state of challenges
-
-    // A)
-    deploy::kubernetes::deploy_challenges(profile_name, &build_results).await?;
-
-    // B)
-    deploy::s3::upload_assets(profile_name, &build_results).await?;
-
-    // C)
-    deploy::frontend::update_frontend(profile_name, &build_results).await?;
+    deploy::deploy_challenges(profile_name, &build_results)
+        .await
+        .context("could not deploy challenges")?;
 
     Ok(())
 }

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,28 +1,26 @@
+use anyhow::{bail, Result};
 use std::path::Path;
 use std::process::exit;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::configparser::{get_challenges, get_config, get_profile_deploy};
 
-pub fn run() {
+pub fn run() -> Result<()> {
     info!("validating config...");
-    let config = match get_config() {
-        Ok(c) => c,
-        Err(err) => {
-            error!("{err:#}");
-            exit(1);
-        }
-    };
+
+    let config = get_config()?;
     info!("  config ok!");
 
     info!("validating challenges...");
+    // print these errors here instead of returning, since its a vec of them
+    // TODO: figure out how to return this error directly
     let chals = match get_challenges() {
         Ok(c) => c,
         Err(errors) => {
             for e in errors.iter() {
                 error!("{e:#}");
             }
-            exit(1);
+            bail!("failed to validate challenges");
         }
     };
     info!("  challenges ok!");
@@ -31,29 +29,28 @@ pub fn run() {
     info!("validating deploy config...");
     for (profile_name, _pconfig) in config.profiles.iter() {
         // fetch from config
-        let deploy_challenges = match get_profile_deploy(profile_name) {
-            Ok(d) => &d.challenges,
-            Err(err) => {
-                error!("{err:#}");
-                exit(1);
-            }
-        };
+        let deploy_challenges = get_profile_deploy(profile_name)?;
 
         // check for missing
         let missing: Vec<_> = deploy_challenges
+            .challenges
             .keys()
             .filter(
                 // try to find any challenge paths in deploy config that do not exist
                 |path| !chals.iter().any(|c| c.directory == Path::new(path)),
             )
             .collect();
+
+        // TODO: figure out how to return this error directly
         if !missing.is_empty() {
             error!(
                 "Deploy settings for profile '{profile_name}' has challenges that do not exist:"
             );
             missing.iter().for_each(|path| error!("  - {path}"));
-            exit(1)
+            bail!("failed to validate deploy config");
         }
     }
-    info!("  deploy ok!")
+    info!("  deploy ok!");
+
+    Ok(())
 }

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -209,6 +209,17 @@ impl ChallengeConfig {
             .split_whitespace()
             .join("-")
     }
+
+    /// Create challenge name slug from directory path (without category)
+    pub fn slugify_name(&self) -> String {
+        self.directory
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_lowercase()
+            .split_whitespace()
+            .join("-")
+    }
 }
 
 fn default_difficulty() -> i64 {

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -12,10 +12,10 @@ use std::str::FromStr;
 use tracing::{debug, error, info, trace, warn};
 use void::Void;
 
-use crate::clients::render_strict;
 use crate::configparser::config::Resource;
 use crate::configparser::field_coersion::string_or_struct;
 use crate::configparser::get_config;
+use crate::utils::render_strict;
 
 pub fn parse_all() -> Result<Vec<ChallengeConfig>, Vec<Error>> {
     // find all challenge.yaml files

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -305,10 +305,16 @@ struct Pod {
     #[serde(default)]
     env: ListOrMap,
 
+    #[serde(default = "default_architecture")]
+    architecture: String,
+
     resources: Option<Resource>,
     replicas: i64,
     ports: Vec<PortConfig>,
     volume: Option<String>,
+}
+fn default_architecture() -> String {
+    "amd64".to_string()
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -122,7 +122,36 @@ pub fn parse_one(path: &PathBuf) -> Result<ChallengeConfig> {
 pub struct ChallengeConfig {
     name: String,
     author: String,
+
+    /// Challenge description, displayed to players on the frontend.
+    /// Supports markdown and Jinja-style templating for challenge info via
+    /// [minijinja](https://docs.rs/minijinja).
+    ///
+    /// The Jinja template fields available are:
+    ///
+    /// | Field name  | Description |
+    /// | ----------- | ----------- |
+    /// | `hostname`  | The hostname or domain for the challenge
+    /// | `port`      | The port that the challenge is listening on
+    /// | `nc`        | Insert the `nc` command to connect to TCP challenges (`nc {{hostname}} {{port}}`)
+    /// | `link`      | Create a Markdown link to the exposed hostname/port
+    /// | `url`       | The URL from `link` without the accompanying Markdown
+    /// | `challenge` | The full challenge.yaml config for this challenge, with subfields
+    ///
+    /// Example:
+    ///
+    /// ```yaml
+    /// description: |
+    ///     Some example challenge. Blah blah blah flavor text.
+    ///
+    ///     In case you missed it, this was written by {{ challenge.author }}
+    ///     and is called {{ challenge.name }}.
+    ///
+    ///     {{ link }}    # -becomes-> [example.chals.thectf.com](https://example.chals.thectf.com)
+    ///     {{ nc }}      # -becomes-> `nc example.chals.thectf.com 12345`
+    /// ```
     description: String,
+
     category: String,
 
     directory: PathBuf,

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -37,6 +37,7 @@ pub async fn update_frontend(
         minijinja::context! {
             challenge => chal,
             host => hostname,
+            hostname => hostname,
             port => chal_port(chal),
             nc => format!("`nc {} {}`", hostname, chal_port(chal)),
             url => format!("[https://{hostname}](https://{hostname})", ),

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -109,7 +109,7 @@ author   | `{author}`
         author = chal.author,
         desc = rendered_desc,
         asset_urls = asset_urls,
-        flag = flag,
+        flag = flag.trim(),
     );
 
     // TODO: proper frontend updates

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -124,7 +124,7 @@ fn chal_domain(chal: &ChallengeConfig, chal_domain: &str) -> String {
     match chal.pods.iter().find(|p| !p.ports.is_empty()) {
         Some(p) => {
             let subdomain = match &p.ports[0].expose {
-                ExposeType::Tcp(_port) => &chal.name,
+                ExposeType::Tcp(_port) => &chal.slugify_name(),
                 ExposeType::Http(hostname) => hostname,
             };
             format!("{subdomain}.{chal_domain}")

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -1,20 +1,147 @@
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::BuildResult;
+use crate::configparser::challenge::{ExposeType, FlagType};
 use crate::configparser::config::ProfileConfig;
 use crate::configparser::{enabled_challenges, get_config, get_profile_config, ChallengeConfig};
+use crate::utils::render_strict;
+
+use super::kubernetes::KubeDeployResult;
+use super::s3::S3DeployResult;
 
 /// Sync deployed challenges with rCTF frontend
 pub async fn update_frontend(
     profile_name: &str,
-    build_results: &[(&ChallengeConfig, BuildResult)],
-) -> Result<()> {
+    chal: &ChallengeConfig,
+    build_result: &BuildResult,
+    kube_result: &KubeDeployResult,
+    s3_result: &S3DeployResult,
+) -> Result<String> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 
-    todo!()
+    // TODO: hook this up to real frontend! Waiting on rCTF frontend reimplementation
+
+    // for now, render out all challenge information to a markdown file for
+    // admins to enter manually
+
+    let hostname = chal_domain(chal, &profile.challenges_domain);
+    let rendered_desc = render_strict(
+        &chal.description,
+        minijinja::context! {
+            challenge => chal,
+            host => hostname,
+            port => chal_port(chal),
+            nc => format!("`nc {} {}`", hostname, chal_port(chal)),
+            url => format!("[https://{hostname}](https://{hostname})", ),
+            link => format!("https://{hostname}"),
+        },
+    )?;
+
+    // urls to markdown links
+    let asset_urls = s3_result
+        .uploaded_asset_urls
+        .iter()
+        .map(|url| {
+            format!(
+                "[{}]({})",
+                Path::new(url)
+                    .file_name()
+                    .expect("asset URL has no path!")
+                    .to_string_lossy(),
+                url
+            )
+        })
+        .join("\n\n");
+    let flag = match &chal.flag {
+        FlagType::RawString(f) => f.clone(),
+        FlagType::File { file } => {
+            let full_path = chal.directory.join(file);
+            let mut flag = String::new();
+            let f = File::open(&full_path)
+                .with_context(|| {
+                    format!(
+                        "could not open flag file {:?} for challenge {:?}",
+                        &full_path, chal.directory
+                    )
+                })?
+                .read_to_string(&mut flag);
+            flag
+        }
+        FlagType::Text { text } => text.clone(),
+        FlagType::Regex { regex } => unimplemented!(),
+        FlagType::Verifier { verifier } => unimplemented!(),
+    };
+
+    let info_md = format!(
+        r"
+##  `{slug}`
+
+|        |   |
+--------:|---|
+name     | `{name}`
+category | `{cat}`
+author   | `{author}`
+
+### description
+
+```
+{desc}
+
+{asset_urls}
+```
+
+### flag
+
+`{flag}`
+
+---
+",
+        slug = chal.slugify_slash(),
+        name = chal.name,
+        cat = chal.category,
+        author = chal.author,
+        desc = rendered_desc,
+        asset_urls = asset_urls,
+        flag = flag,
+    );
+
+    // TODO: proper frontend updates
+
+    Ok(info_md)
+}
+
+// TODO: move to impl ChallengeConfig?
+// TODO: return Option and report errors when missing
+fn chal_domain(chal: &ChallengeConfig, chal_domain: &str) -> String {
+    // find first container with expose
+    match chal.pods.iter().find(|p| !p.ports.is_empty()) {
+        Some(p) => {
+            let subdomain = match &p.ports[0].expose {
+                ExposeType::Tcp(_port) => &chal.name,
+                ExposeType::Http(hostname) => hostname,
+            };
+            format!("{subdomain}.{chal_domain}")
+        }
+        // no pods have expose, no hostname for challenge
+        None => "".to_string(),
+    }
+}
+
+fn chal_port(chal: &ChallengeConfig) -> &i64 {
+    // find first container with expose
+    match chal.pods.iter().find(|p| !p.ports.is_empty()) {
+        Some(p) => match &p.ports[0].expose {
+            ExposeType::Tcp(port) => port,
+            ExposeType::Http(_hostname) => &443,
+        },
+        // no pods have expose, no hostname for challenge
+        None => &0,
+    }
 }

--- a/src/deploy/kubernetes/mod.rs
+++ b/src/deploy/kubernetes/mod.rs
@@ -136,7 +136,7 @@ pub async fn apply_challenge_resources(
                 templates::CHALLENGE_SERVICE_TCP,
                 minijinja::context! {
                     chal, pod, tcp_ports,
-                    slug => chal.slugify(), domain => profile.challenges_domain
+                    slug => chal.slugify(), name_slug => chal.slugify_name(), domain => profile.challenges_domain
                 },
             )?;
             trace!("TCP SERVICE:\n{}", tcp_manifest);

--- a/src/deploy/kubernetes/templates.rs
+++ b/src/deploy/kubernetes/templates.rs
@@ -11,3 +11,6 @@ pub static CHALLENGE_SERVICE_HTTP: &str =
 
 pub static CHALLENGE_SERVICE_TCP: &str =
     include_str!("../../asset_files/challenge_templates/tcp.yaml.j2");
+
+pub static IMAGE_PULL_CREDS_SECRET: &str =
+    include_str!("../../asset_files/challenge_templates/pull-secret.yaml.j2");

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,19 @@ fn main() {
         .init();
 
     trace!("args: {:?}", cli);
+
     // dispatch commands
+    match dispatch(cli) {
+        Ok(_) => (),
+        Err(e) => {
+            error!("{e:?}");
+            std::process::exit(1)
+        }
+    };
+}
+
+/// dispatch commands
+fn dispatch(cli: cli::Cli) -> anyhow::Result<()> {
     match &cli.command {
         cli::Commands::Validate => commands::validate::run(),
 
@@ -49,7 +61,7 @@ fn main() {
             registry,
             bucket,
         } => {
-            commands::validate::run();
+            commands::validate::run()?;
             commands::check_access::run(profile, kubernetes, frontend, registry, bucket)
         }
 
@@ -60,7 +72,7 @@ fn main() {
             no_push,
             extract_assets,
         } => {
-            commands::validate::run();
+            commands::validate::run()?;
             commands::build::run(profile, &!no_push, extract_assets)
         }
 
@@ -69,12 +81,13 @@ fn main() {
             no_build,
             dry_run,
         } => {
-            commands::validate::run();
+            commands::validate::run()?;
             commands::deploy::run(profile, no_build, dry_run)
         }
 
         cli::Commands::ClusterSetup { profile } => {
-            commands::cluster_setup::run(profile);
+            commands::validate::run()?;
+            commands::cluster_setup::run(profile)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use beavercds_ng::commands;
 use clap::Parser;
-use tracing::{trace, Level};
+use tracing::{error, trace, Level};
 use tracing_subscriber::{
     fmt::{format::FmtSpan, time},
     EnvFilter,

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -357,6 +357,7 @@ fn challenge_pods() {
                     replicas: 2,
                     env: ListOrMap::Map(HashMap::new()),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 80,
                         expose: ExposeType::Http("test.chals.example.com".to_string())
@@ -373,6 +374,7 @@ fn challenge_pods() {
                     replicas: 1,
                     env: ListOrMap::Map(HashMap::new()),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 8000,
                         expose: ExposeType::Tcp(12345)
@@ -442,6 +444,7 @@ fn challenge_pod_build() {
                     replicas: 1,
                     env: ListOrMap::Map(HashMap::new()),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 80,
                         expose: ExposeType::Http("test.chals.example.com".to_string())
@@ -461,6 +464,7 @@ fn challenge_pod_build() {
                     replicas: 1,
                     env: ListOrMap::Map(HashMap::new()),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 80,
                         expose: ExposeType::Http("test2.chals.example.com".to_string())
@@ -530,6 +534,7 @@ fn challenge_pod_env() {
                         ("BAR".to_string(), "that".to_string()),
                     ])),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 80,
                         expose: ExposeType::Http("test.chals.example.com".to_string())
@@ -545,6 +550,7 @@ fn challenge_pod_env() {
                         ("BAR".to_string(), "that".to_string()),
                     ])),
                     resources: None,
+                    architecture: "amd64".to_string(),
                     ports: vec![PortConfig {
                         internal: 80,
                         expose: ExposeType::Http("test2.chals.example.com".to_string())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use futures::{future::try_join_all, TryFuture};
 
 /// Helper trait for `Iterator` to add futures::try_await_all() as chain method.
@@ -25,4 +26,20 @@ where
     ) -> Result<Vec<<Self::Item as TryFuture>::Ok>, <Self::Item as TryFuture>::Error> {
         try_join_all(self).await
     }
+}
+
+//
+// Minijinja strict rendering with error
+//
+
+/// Similar to minijinja.render!(), but return Error if any undefined values.
+pub fn render_strict(template: &str, context: minijinja::Value) -> Result<String> {
+    let mut strict_env = minijinja::Environment::new();
+    // error on any undefined template variables
+    strict_env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+
+    let r = strict_env
+        .render_str(template, context)
+        .context(format!("could not render template {:?}", template))?;
+    Ok(r)
 }

--- a/tests/repo/pwn/notsh/challenge.yaml
+++ b/tests/repo/pwn/notsh/challenge.yaml
@@ -1,4 +1,4 @@
-name: notsh
+name: not a shell?
 author: captainGeech
 description: |-
   This challenge isn't a shell

--- a/tests/repo/web/bar/challenge.yaml
+++ b/tests/repo/web/bar/challenge.yaml
@@ -8,7 +8,7 @@ description: |
 difficulty: 1
 
 flag:
-  file: ./flag
+  file: ./site_source/flag
 
 # each individual pod is gonna allow only 1 container for now
 pods:


### PR DESCRIPTION
Changes during DamCTF crunch time to get things working.

Notable changes:
- render templates in strict mode to error on undefined variables (added a helper for that)
- check for `helm` binary in cluster-setup
- add needed AWS ELB annotations to ingress and tcp services to get public load balancer
- switch to [official external-dns chart](https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/) instead of [bitnami external-dns](https://github.com/bitnami/charts/tree/main/bitnami/external-dns) because it works better  ( closes #51 )
- Basic documentation for challenge authors on the new challenge.yaml format
- Apply `registry.cluster` image pull credentials to cluster
- Hacky TCP challenge fix to use the challenge name as part of the DNS entry (will change in #64)
- Render challenge information to a local markdown file instead of sending to frontend
- Use local `docker.io` dockerhub credentials when building images if available ( closes #59 )
- Allow specifying `architecture` in challenge pod config for pods that need to run on `arm64` (defaults to `amd64`) ( closes #55 )
- Reworked deployment code structure to handle kube apply, s3 upload, and frontend updates on a per-challenge instead of separately to properly pass s3 info to frontend