### PR TITLE
Use presigned url to get the public bucket url for asset files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "void",
  "zip",
 ]
@@ -836,9 +837,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1473,9 +1474,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2023,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -3217,13 +3218,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ figment = { version = "0.10.19", features = ["env", "yaml", "test"] }
 zip = { version = "2.2.2", default-features = false, features = ["deflate"] }
 regex = "1.11.1"
 inquire = "0.7.5"
+url = "2.5.8"
 
 # tracing
 tracing = { version = "0.1.41", features = ["attributes"] }

--- a/src/deploy/s3.rs
+++ b/src/deploy/s3.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use s3::Bucket;
 use tokio;
 use tracing::{debug, error, info, trace, warn};
+use url::Url;
 
 use crate::builder::BuildResult;
 use crate::clients::bucket_client;
@@ -33,25 +34,36 @@ pub async fn upload_challenge_assets(
 
     info!("uploading assets for chal {:?}...", chal.directory);
 
+    // Upload each asset and collect the public url for each object.
     let uploaded = build_result
         .assets
         .iter()
         .map(|asset_file| async move {
             debug!("uploading file {:?}", asset_file);
-            // upload to bucket
-            let bucket_path = upload_single_file(bucket, chal, asset_file)
+            // Upload file to the bucket
+            let path_in_bucket = upload_single_file(bucket, chal, asset_file)
                 .await
                 .with_context(|| format!("failed to upload file {asset_file:?}"))?;
 
-            // return link to the uploaded file
-            // TODO: only works for AWS rn! support other providers
-            let url = format!(
-                "https://{bucket}.s3.{region}.amazonaws.com/{path}",
-                bucket = &profile.s3.bucket_name,
-                region = &profile.s3.region,
-                path = bucket_path.to_string_lossy(),
-            );
-            Ok(url)
+            // S3 API does not have a method to get the public URL, but does
+            // have one to create a presigned URL. We need the server to give us
+            // the correct URL since we can't reliably assume the format of the
+            // full URL for non-AWS storage providers that all have different
+            // formats for combining the endpoint and region.
+            //
+            // Generate a presigned url with expiry in one second, just to make
+            // sure this can't be used.
+            let presigned_url = bucket
+                .presign_get(path_in_bucket.to_string_lossy(), 1, None)
+                .await
+                .context("failed to fetch presigned url")?;
+            trace!("got temporary presigned GET: {presigned_url}");
+
+            // Strip off the signing parameters to get the public object url
+            let mut url = Url::parse(&presigned_url)?;
+            url.set_query(None);
+
+            Ok(url.to_string())
         })
         .try_join_all()
         .await


### PR DESCRIPTION
Since the S3 API doesn't have a method to get the url of objects for public buckets, but does to create a presigned url. We can't reliably construct the url from the s3 client endpoint and region as different providers have different formats for that, so this has to get the url from the S3 server somehow.

Resolves https://github.com/osusec/beavercds-backend/issues/79.