### PR TITLE
Deploy challenge info to frontend 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ dependencies = [
  "regex",
  "rust-s3",
  "serde",
- "serde_nested_with",
+ "serde_with",
  "serde_yaml_ng",
  "tar",
  "tempfile",
@@ -371,6 +371,15 @@ dependencies = [
  "serde",
  "serde_repr",
  "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -464,7 +473,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -644,8 +653,18 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -659,7 +678,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -668,19 +700,30 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
  "quote",
- "syn 2.0.87",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -691,7 +734,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -719,7 +762,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -778,7 +821,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -804,7 +847,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -916,7 +959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd8cb48eceb4e8b471af6a8e4e223cbe1286552791b9ab274512ba9cfd754df"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -975,7 +1018,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1528,7 +1571,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1665,7 +1708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1786,7 +1829,7 @@ dependencies = [
  "http 1.2.0",
  "json-patch",
  "k8s-openapi",
- "schemars",
+ "schemars 0.8.21",
  "serde",
  "serde-value",
  "serde_json",
@@ -1799,12 +1842,12 @@ version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1915,7 +1958,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2000,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2124,7 +2167,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2174,7 +2217,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2205,7 +2248,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2237,30 +2280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2296,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -2308,6 +2327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2560,7 +2599,7 @@ dependencies = [
  "security-framework 3.0.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2638,6 +2677,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2712,10 +2775,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2730,14 +2794,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.214"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2748,31 +2821,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_nested_with"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e5de5df86900414dd5f677bcf85486948fdb36c84d4aad54434b9bcdd2d574"
-dependencies = [
- "darling",
- "proc-macro-error",
- "quote",
- "syn 2.0.87",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2783,7 +2845,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2800,19 +2862,34 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.6.0",
- "serde",
- "serde_derive",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
  "serde_json",
+ "serde_with_macros",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2975,16 +3052,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
@@ -3008,7 +3075,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3061,7 +3128,7 @@ checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3072,7 +3139,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3087,30 +3154,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3134,6 +3201,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3160,7 +3242,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3276,7 +3358,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3528,7 +3610,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3550,7 +3632,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3610,7 +3692,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3901,7 +3983,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -3922,7 +4004,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3942,7 +4024,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "synstructure",
 ]
 
@@ -3971,7 +4053,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -3990,6 +4072,12 @@ dependencies = [
  "thiserror 2.0.9",
  "zopfli",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -302,6 +302,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "url",
  "void",
  "zip",
@@ -502,6 +503,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.6.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +714,15 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1270,7 +1309,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.21",
+ "rustls 0.23.36",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -1653,7 +1692,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.21",
+ "rustls 0.23.36",
  "secrecy",
  "serde",
  "serde_json",
@@ -1762,6 +1801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,9 +1824,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -2349,15 +2394,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -2420,9 +2465,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2439,6 +2487,17 @@ name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3001,7 +3060,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.21",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3217,6 +3276,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.2.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3318,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -3339,6 +3436,15 @@ name = "webpki-roots"
 version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +552,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1599,6 +1625,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.68",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,7 +2486,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2429,7 +2499,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2442,7 +2512,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2471,6 +2541,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.0",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.0.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2509,6 +2606,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2575,7 +2681,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3288,6 +3407,7 @@ dependencies = [
  "percent-encoding",
  "rustls 0.23.36",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "ureq-proto",
@@ -3362,6 +3482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +3605,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3515,6 +3672,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3550,6 +3722,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3562,6 +3740,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3571,6 +3755,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3592,6 +3782,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3601,6 +3797,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3616,6 +3818,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3625,6 +3833,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ duct = "0.13.7"
 fastrand = "2.3.0"
 base64ct = { version = "1.7.3", features = ["alloc"] }
 docker_credential = "1.3.2"
-ureq = { version = "3.1.4", features = ["json"] }
+ureq = { version = "3.1.4", features = ["json", "platform-verifier"] }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ duct = "0.13.7"
 fastrand = "2.3.0"
 base64ct = { version = "1.7.3", features = ["alloc"] }
 docker_credential = "1.3.2"
+ureq = { version = "3.1.4", features = ["json"] }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ itertools = "0.12.1"
 glob = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
-serde_nested_with = "0.2.5"
 fully_pub = "0.1.4"
 void = "1"
 futures = "0.3.30"
@@ -19,6 +18,7 @@ zip = { version = "2.2.2", default-features = false, features = ["deflate"] }
 regex = "1.11.1"
 inquire = "0.7.5"
 url = "2.5.8"
+serde_with = "3.19.0"
 
 # tracing
 tracing = { version = "0.1.41", features = ["attributes"] }

--- a/src/access_handlers/frontend.rs
+++ b/src/access_handlers/frontend.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tracing::debug;
-use ureq;
+use ureq::tls::{RootCerts, TlsConfig};
+use ureq::Agent;
 
 use crate::configparser::{get_config, get_profile_config};
 
@@ -17,7 +18,17 @@ pub fn check(profile_name: &str) -> Result<()> {
 
     debug!("checking frontend access at {}", profile.frontend_url);
 
-    let resp = ureq::get(format!("{}/api/checkaccess", profile.frontend_url))
+    let agent = Agent::config_builder()
+        .tls_config(
+            TlsConfig::builder()
+                .root_certs(RootCerts::PlatformVerifier)
+                .build(),
+        )
+        .build()
+        .new_agent();
+
+    let resp = agent
+        .get(format!("{}/api/checkaccess", profile.frontend_url))
         .header("Authorization", format!("Token {}", profile.frontend_token))
         .call()
         .context("could not reach frontend API")?;

--- a/src/access_handlers/frontend.rs
+++ b/src/access_handlers/frontend.rs
@@ -1,9 +1,43 @@
-use anyhow::{Error, Result};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tracing::debug;
+use ureq;
 
 use crate::configparser::{get_config, get_profile_config};
 
-/// frontend dashbard access checks
+#[derive(Deserialize, Debug)]
+/// Returned JSON object from frontend (`{"status":"ok"}`)
+struct CheckAccessResponse {
+    status: String,
+}
+
+/// frontend dashboard access checks
 pub fn check(profile_name: &str) -> Result<()> {
     let profile = get_profile_config(profile_name)?;
+
+    debug!("checking frontend access at {}", profile.frontend_url);
+
+    let resp = ureq::get(format!("{}/api/checkaccess", profile.frontend_url))
+        .header("Authorization", format!("Token {}", profile.frontend_token))
+        .call()
+        .context("could not reach frontend API")?;
+
+    if resp.status() != 200 {
+        bail!(
+            "frontend returned unexpected status code: {}",
+            resp.status()
+        );
+    }
+
+    // also check content to make sure we're hitting frontend API
+    let body: CheckAccessResponse = resp
+        .into_body()
+        .read_json()
+        .context("frontend response was not valid JSON")?;
+
+    if body.status != "ok" {
+        bail!("frontend returned unexpected status: {:?}", body);
+    }
+
     Ok(())
 }

--- a/src/asset_files/challenge_templates/deployment.yaml.j2
+++ b/src/asset_files/challenge_templates/deployment.yaml.j2
@@ -28,7 +28,7 @@ spec:
           image: "{{ pod_image }}"
           imagePullPolicy: Always
           ports:
-            {% for p in pod.ports -%}
+            {% for p in pod.ports | unique(attribute="internal") %}
             - containerPort: {{ p.internal }}
             {%- else %}
             []
@@ -36,7 +36,7 @@ spec:
 
           {% if pod.env -%}
           env:
-            {% for k, v in pod.env -%}
+            {% for k, v in pod.env | items %}
             - { name: "{{ k }}", value: "{{ v }}" }
             {%- else %}
             []

--- a/src/asset_files/challenge_templates/http.yaml.j2
+++ b/src/asset_files/challenge_templates/http.yaml.j2
@@ -11,7 +11,7 @@ spec:
     rctf/part-of: "{{ slug }}-{{ pod.name }}"
   ports:
     # host service at same port as container
-    {% for p in http_ports -%}
+    {%- for p in http_ports | unique(attribute="internal") %}
     - port: {{ p.internal }}
       targetPort: {{ p.internal }}
     {%- endfor %}

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use itertools::Itertools;
 use std::path::Path;
 use std::process::exit;
 use tracing::{debug, error, info, trace, warn};
@@ -36,6 +37,7 @@ pub fn run() -> Result<()> {
             bail!("failed to validate challenges");
         }
     };
+
     // double check specific things about challenges
     for chal in chals {
         // does point class exist in default config?
@@ -48,6 +50,23 @@ pub fn run() -> Result<()> {
                 )
             }
         }
+    }
+
+    // are all challenge ids unique?
+    // find any challenges with duplicate ids
+    let dups = chals
+        .iter()
+        .duplicates_by(|c| &c.challenge_id)
+        .collect_vec();
+    if !dups.is_empty() {
+        // fetch the other challenge with the duplicate id. duplicates() only
+        // returns the second duplicating item, not both, so need to get it.
+        let duped_chals = chals
+            .iter()
+            .filter(|c| dups.iter().any(|d| d.challenge_id == c.challenge_id))
+            .map(|c| c.slugify_slash())
+            .collect_vec();
+        bail!("challenge IDs for chals {:?} conflict", duped_chals);
     }
 
     info!("  challenges ok!");

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -9,6 +9,19 @@ pub fn run() -> Result<()> {
     info!("validating config...");
 
     let config = get_config()?;
+
+    // is point class max/min order correct?
+    for class in config.point_classes.iter() {
+        if class.min > class.max {
+            bail!(
+                "min/max points are backwards for point class '{}' (min: {} > max: {})",
+                class.name,
+                class.min,
+                class.max
+            )
+        }
+    }
+
     info!("  config ok!");
 
     info!("validating challenges...");

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -89,7 +89,9 @@ pub fn parse_one(path: &PathBuf) -> Result<ChallengeConfig> {
                         if split.len() == 2 {
                             Ok((split[0].to_string(), split[1].to_string()))
                         } else {
-                            Err(anyhow!("Cannot split envvar {var:?}"))
+                            Err(anyhow!(
+                                "could not parse envvar=value from {var:?} (missing '='?)"
+                            ))
                         }
                     })
                     .collect::<Result<_>>()?;

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -384,7 +384,7 @@ struct PortConfig {
     expose: ExposeType,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 #[fully_pub]
 enum ExposeType {

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -6,8 +6,6 @@ use glob::glob;
 use itertools::Itertools;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, DeserializeAs};
-use std::fmt::Display;
-// use serde_nested_with::serde_nested;
 use std::collections::HashMap as Map;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -162,6 +162,8 @@ pub struct ChallengeConfig {
     // if not set.
     point_class: Option<String>,
 
+    challenge_id: String,
+
     flag: FlagType,
 
     #[serde(default)]

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -4,8 +4,10 @@ use figment::Figment;
 use fully_pub::fully_pub;
 use glob::glob;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use serde_nested_with::serde_nested;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{serde_as, DeserializeAs};
+use std::fmt::Display;
+// use serde_nested_with::serde_nested;
 use std::collections::HashMap as Map;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -117,8 +119,23 @@ pub fn parse_one(path: &PathBuf) -> Result<ChallengeConfig> {
 //
 // ==== Structs for challenge.yaml parsing ====
 //
+struct StringOrStruct;
 
-#[serde_nested]
+// Add implementation for DeserializeAs to avoid needing deserialize_with
+impl<'de, T> DeserializeAs<'de, T> for StringOrStruct
+where
+    T: Deserialize<'de> + FromStr<Err = Void>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        string_or_struct(deserializer)
+    }
+}
+
+// #[serde_nested]
+#[serde_as]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[fully_pub]
@@ -169,8 +186,7 @@ pub struct ChallengeConfig {
     flag: FlagType,
 
     #[serde(default)]
-    // map deserialize_with to type in vec
-    #[serde_nested(sub = "ProvideConfig", serde(deserialize_with = "string_or_struct"))]
+    #[serde_as(deserialize_as = "Vec<StringOrStruct>")]
     provide: Vec<ProvideConfig>, // optional if no files provided
 
     #[serde(default)]

--- a/src/configparser/challenge.rs
+++ b/src/configparser/challenge.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, trace, warn};
 use void::Void;
 
 use crate::configparser::config::Resource;
-use crate::configparser::field_coersion::string_or_struct;
+use crate::configparser::field_coersion::{string_or_struct, StringOrStruct};
 use crate::configparser::get_config;
 use crate::utils::render_strict;
 
@@ -119,22 +119,7 @@ pub fn parse_one(path: &PathBuf) -> Result<ChallengeConfig> {
 //
 // ==== Structs for challenge.yaml parsing ====
 //
-struct StringOrStruct;
 
-// Add implementation for DeserializeAs to avoid needing deserialize_with
-impl<'de, T> DeserializeAs<'de, T> for StringOrStruct
-where
-    T: Deserialize<'de> + FromStr<Err = Void>,
-{
-    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        string_or_struct(deserializer)
-    }
-}
-
-// #[serde_nested]
 #[serde_as]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/configparser/config.rs
+++ b/src/configparser/config.rs
@@ -131,8 +131,8 @@ struct Defaults {
 struct PointClass {
     /// Name of this difficulty level
     name: String,
-    min: i64,
-    max: i64,
+    min: u32,
+    max: u32,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/configparser/field_coersion.rs
+++ b/src/configparser/field_coersion.rs
@@ -8,7 +8,25 @@ use std::str::FromStr;
 
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
+use serde_with::DeserializeAs;
 use void::Void;
+
+pub struct StringOrStruct;
+
+// Add implementation for DeserializeAs since stock serde(deserialize_with)
+// does not work for nested types, e.g. Vec<CouldBeString> -- use serde_with
+// to work around that which requires this trait impl and not a raw function.
+impl<'de, T> DeserializeAs<'de, T> for StringOrStruct
+where
+    T: Deserialize<'de> + FromStr<Err = Void>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        string_or_struct(deserializer)
+    }
+}
 
 pub fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -24,8 +24,8 @@ pub struct FrontendChalData {
     author: String,
     category: String,
     description: String,
-    min_points: u32,
-    max_points: u32,
+    min_points: i64,
+    max_points: i64,
     flag: String,
     files: Vec<String>,
 }
@@ -57,6 +57,7 @@ pub async fn render_frontend_info(
     kube_result: &KubeDeployResult,
     s3_result: &S3DeployResult,
 ) -> Result<FrontendChalData> {
+    let config = get_config()?;
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 
@@ -96,14 +97,26 @@ pub async fn render_frontend_info(
         FlagType::Verifier { verifier } => unimplemented!("flag custom verifier not implemented"),
     };
 
+    // Get point class from challenge or use default from repo config
+    let point_class_name = chal
+        .point_class
+        .as_ref()
+        .unwrap_or(&config.defaults.point_class);
+    // Then look the class name up in the repo config
+    let point_info = config
+        .point_classes
+        .iter()
+        .find(|class| class.name == *point_class_name)
+        .ok_or(anyhow!("challenge points are missing in config"))?;
+
     let chal_data = FrontendChalData {
         id: chal.slugify_slash(),
         name: chal.name.to_string(),
         author: chal.author.to_string(),
         category: chal.category.to_string(),
         description: rendered_desc,
-        min_points: 0, // TODO! lookup
-        max_points: 0, // TODO! lookup
+        min_points: point_info.min,
+        max_points: point_info.max,
         flag,
         files: s3_result.uploaded_asset_urls.clone(),
     };

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, trace, warn};
 use ureq;
 
@@ -30,19 +30,29 @@ pub struct FrontendChalData {
     files: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct FrontendResolveResponse {
+    current: Vec<String>,
+    removed: Vec<String>,
+}
+
 /// Post collected challenge info structs to frontend. Returns the response
 /// from frontend.
 pub async fn update_frontend(
     profile_name: &str,
     chal_infos: &[FrontendChalData],
-) -> Result<String> {
+) -> Result<FrontendResolveResponse> {
     let profile = get_profile_config(profile_name)?;
 
-    let resp = ureq::post(format!("{}/chals/resolvestate", profile.frontend_url))
+    let resp = ureq::post(format!("{}/api/resolvestate", profile.frontend_url))
         .header("Authorization", format!("Token {}", profile.frontend_token))
         .send_json(chal_infos)
         .context("could not update frontend with challenge info")?;
-    let body = resp.into_body().read_to_string()?;
+
+    let body: FrontendResolveResponse = resp
+        .into_body()
+        .read_json()
+        .context("got malformed response from frontend")?;
 
     debug!("got response from frontend: {:?}", body);
 

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -24,8 +24,8 @@ pub struct FrontendChalData {
     author: String,
     category: String,
     description: String,
-    min_points: i64,
-    max_points: i64,
+    min_points: u32,
+    max_points: u32,
     flag: String,
     files: Vec<String>,
 }

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -30,18 +30,23 @@ pub struct FrontendChalData {
     files: Vec<String>,
 }
 
-/// Post collected challenge info structs to frontend
-pub async fn update_frontend(profile_name: &str, chal_infos: &[FrontendChalData]) -> Result<()> {
+/// Post collected challenge info structs to frontend. Returns the response
+/// from frontend.
+pub async fn update_frontend(
+    profile_name: &str,
+    chal_infos: &[FrontendChalData],
+) -> Result<String> {
     let profile = get_profile_config(profile_name)?;
 
-    // Post collected challenge info to frontend
     let resp = ureq::post(format!("{}/chals/resolvestate", profile.frontend_url))
         .header("Authorization", format!("Token {}", profile.frontend_token))
         .send_json(chal_infos)
         .context("could not update frontend with challenge info")?;
-    // let json = resp.body().read_json()?;
+    let body = resp.into_body().read_to_string()?;
 
-    Ok(())
+    debug!("got response from frontend: {:?}", body);
+
+    Ok(body)
 }
 
 /// Sync deployed challenges with rCTF frontend

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -6,7 +6,8 @@ use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, trace, warn};
-use ureq;
+use ureq::tls::{RootCerts, TlsConfig};
+use ureq::Agent;
 
 use crate::builder::BuildResult;
 use crate::configparser::challenge::{ExposeType, FlagType};
@@ -45,7 +46,17 @@ pub async fn update_frontend(
 ) -> Result<FrontendResolveResponse> {
     let profile = get_profile_config(profile_name)?;
 
-    let resp = ureq::post(format!("{}/api/resolvestate", profile.frontend_url))
+    let agent = Agent::config_builder()
+        .tls_config(
+            TlsConfig::builder()
+                .root_certs(RootCerts::PlatformVerifier)
+                .build(),
+        )
+        .build()
+        .new_agent();
+
+    let resp = agent
+        .post(format!("{}/api/resolvestate", profile.frontend_url))
         .header("Authorization", format!("Token {}", profile.frontend_token))
         .send_json(chal_infos)
         .context("could not update frontend with challenge info")?;

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Error, Ok, Result};
 use itertools::Itertools;
+use serde::Serialize;
 use tracing::{debug, error, info, trace, warn};
+use ureq;
 
 use crate::builder::BuildResult;
 use crate::configparser::challenge::{ExposeType, FlagType};
@@ -15,21 +17,45 @@ use crate::utils::render_strict;
 use super::kubernetes::KubeDeployResult;
 use super::s3::S3DeployResult;
 
+#[derive(Debug, Serialize)]
+pub struct FrontendChalData {
+    id: String,
+    name: String,
+    author: String,
+    category: String,
+    description: String,
+    min_points: u32,
+    max_points: u32,
+    flag: String,
+    files: Vec<String>,
+}
+
+/// Post collected challenge info structs to frontend
+pub async fn update_frontend(profile_name: &str, chal_infos: &[FrontendChalData]) -> Result<()> {
+    let profile = get_profile_config(profile_name)?;
+
+    // Post collected challenge info to frontend
+    let resp = ureq::post(format!("{}/chals/resolvestate", profile.frontend_url))
+        .header("Authorization", format!("Token {}", profile.frontend_token))
+        .send_json(chal_infos)
+        .context("could not update frontend with challenge info")?;
+    // let json = resp.body().read_json()?;
+
+    Ok(())
+}
+
 /// Sync deployed challenges with rCTF frontend
-pub async fn update_frontend(
+pub async fn render_frontend_info(
     profile_name: &str,
     chal: &ChallengeConfig,
     build_result: &BuildResult,
     kube_result: &KubeDeployResult,
     s3_result: &S3DeployResult,
-) -> Result<String> {
+) -> Result<FrontendChalData> {
     let profile = get_profile_config(profile_name)?;
     let enabled_challenges = enabled_challenges(profile_name)?;
 
-    // TODO: hook this up to real frontend! Waiting on rCTF frontend reimplementation
-
-    // for now, render out all challenge information to a markdown file for
-    // admins to enter manually
+    // collect and render challenge info
 
     let hostname = chal_domain(chal, &profile.challenges_domain);
     let rendered_desc = render_strict(
@@ -45,21 +71,6 @@ pub async fn update_frontend(
         },
     )?;
 
-    // urls to markdown links
-    let asset_urls = s3_result
-        .uploaded_asset_urls
-        .iter()
-        .map(|url| {
-            format!(
-                "[{}]({})",
-                Path::new(url)
-                    .file_name()
-                    .expect("asset URL has no path!")
-                    .to_string_lossy(),
-                url
-            )
-        })
-        .join("\n\n");
     let flag = match &chal.flag {
         FlagType::RawString(f) => f.clone(),
         FlagType::File { file } => {
@@ -76,46 +87,23 @@ pub async fn update_frontend(
             flag
         }
         FlagType::Text { text } => text.clone(),
-        FlagType::Regex { regex } => unimplemented!(),
-        FlagType::Verifier { verifier } => unimplemented!(),
+        FlagType::Regex { regex } => unimplemented!("flag regex not implemented"),
+        FlagType::Verifier { verifier } => unimplemented!("flag custom verifier not implemented"),
     };
 
-    let info_md = format!(
-        r"
-##  `{slug}`
+    let chal_data = FrontendChalData {
+        id: chal.slugify_slash(),
+        name: chal.name.to_string(),
+        author: chal.author.to_string(),
+        category: chal.category.to_string(),
+        description: rendered_desc,
+        min_points: 0, // TODO! lookup
+        max_points: 0, // TODO! lookup
+        flag,
+        files: s3_result.uploaded_asset_urls.clone(),
+    };
 
-|        |   |
---------:|---|
-name     | `{name}`
-category | `{cat}`
-author   | `{author}`
-
-### description
-
-```
-{desc}
-
-{asset_urls}
-```
-
-### flag
-
-`{flag}`
-
----
-",
-        slug = chal.slugify_slash(),
-        name = chal.name,
-        cat = chal.category,
-        author = chal.author,
-        desc = rendered_desc,
-        asset_urls = asset_urls,
-        flag = flag.trim(),
-    );
-
-    // TODO: proper frontend updates
-
-    Ok(info_md)
+    Ok(chal_data)
 }
 
 // TODO: move to impl ChallengeConfig?

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -110,7 +110,7 @@ pub async fn render_frontend_info(
         .ok_or(anyhow!("challenge points are missing in config"))?;
 
     let chal_data = FrontendChalData {
-        id: chal.slugify_slash(),
+        id: chal.challenge_id.to_string(),
         name: chal.name.to_string(),
         author: chal.author.to_string(),
         category: chal.category.to_string(),

--- a/src/deploy/frontend.rs
+++ b/src/deploy/frontend.rs
@@ -31,6 +31,7 @@ pub struct FrontendChalData {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)] // used to validate response schema only
 pub struct FrontendResolveResponse {
     current: Vec<String>,
     removed: Vec<String>,

--- a/src/deploy/kubernetes/mod.rs
+++ b/src/deploy/kubernetes/mod.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::builder::BuildResult;
 use crate::clients::{apply_manifest_yaml, kube_client, wait_for_status};
-use crate::configparser::challenge::ExposeType;
+use crate::configparser::challenge::{ExposeType, Pod};
 use crate::configparser::config::ProfileConfig;
 use crate::configparser::{get_config, get_profile_config, ChallengeConfig};
 use crate::utils::{render_strict, TryJoinAll};
@@ -21,12 +21,7 @@ pub mod templates;
 /// How and where a challenge was deployed/exposed at
 pub struct KubeDeployResult {
     // challenges could have multiple exposed services
-    pub exposed: Vec<PodDeployResult>,
-}
-
-pub enum PodDeployResult {
-    Http { domain: String },
-    Tcp { port: usize },
+    pub exposed: Vec<ExposeType>,
 }
 
 // Deploy all K8S resources for a single challenge `chal`.
@@ -86,9 +81,10 @@ pub async fn apply_challenge_resources(
 
     // namespace boilerplate over, deploy actual challenge pods
 
-    let results = KubeDeployResult { exposed: vec![] };
+    let mut results = KubeDeployResult { exposed: vec![] };
 
-    for pod in &chal.pods {
+    // nested function for better error context reporting
+    let mut apply_challenge_pod = async |pod: &Pod| {
         let pod_image = chal.container_tag_for_pod(profile_name, &pod.name)?;
         let depl_manifest = render_strict(
             templates::CHALLENGE_DEPLOYMENT,
@@ -166,8 +162,9 @@ pub async fn apply_challenge_resources(
                     })?;
             }
 
-            // TODO:
-            // expose_results.exposed.push(PodDeployResult::Tcp { port: tcp_ports[0]. });
+            results
+                .exposed
+                .extend(tcp_ports.iter().map(|p| p.expose.to_owned()));
         }
 
         if !http_ports.is_empty() {
@@ -204,7 +201,19 @@ pub async fn apply_challenge_resources(
                         )
                     })?;
             }
+
+            results
+                .exposed
+                .extend(http_ports.iter().map(|p| p.expose.to_owned()));
         }
+
+        Ok(())
+    };
+
+    for pod in &chal.pods {
+        apply_challenge_pod(pod)
+            .await
+            .with_context(|| format!("failed to deploy challenge pod {:?}", pod.name))?;
     }
 
     Ok(results)

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -127,7 +127,7 @@ pub async fn deploy_challenges(
         .try_join_all()
         .await?;
 
-    debug!("collected challenge info: {:?}", chal_infos);
+    debug!("collected challenge info: {:#?}", chal_infos);
 
     // now update frontend with that info
     frontend::update_frontend(profile_name, &chal_infos).await?;

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -116,27 +116,32 @@ pub async fn check_setup(profile: &ProfileConfig) -> Result<()> {
 pub async fn deploy_challenges(
     profile_name: &str,
     build_results: &[(&ChallengeConfig, BuildResult)],
-) -> Result<Vec<()>> {
-    let profile = get_profile_config(profile_name)?;
-
-    build_results
+) -> Result<()> {
+    let chal_infos = build_results
         .iter()
         .map(|(chal, build)| async {
-            let chal_md = deploy_single_challenge(profile_name, chal, build)
+            deploy_single_challenge(profile_name, chal, build)
                 .await
-                .with_context(|| format!("could not deploy challenge {:?}", chal.directory))?;
-            Ok(())
+                .with_context(|| format!("could not deploy challenge {:?}", chal.directory))
         })
         .try_join_all()
-        .await
+        .await?;
+
+    debug!("collected challenge info: {:?}", chal_infos);
+
+    // now update frontend with that info
+    frontend::update_frontend(profile_name, &chal_infos).await?;
+
+    Ok(())
 }
 
-/// Deploy / upload all components of a single challenge.
+/// Deploy / upload all components of a single challenge. Returns a single
+/// struct of challenge info in the format that frontend wants.
 async fn deploy_single_challenge(
     profile_name: &str,
     chal: &ChallengeConfig,
     build_result: &BuildResult,
-) -> Result<String> {
+) -> Result<frontend::FrontendChalData> {
     info!("  deploying chal {:?}...", chal.directory);
     // deploy needs to:
     // A) render kubernetes manifests
@@ -152,7 +157,7 @@ async fn deploy_single_challenge(
     let s3_urls = s3::upload_challenge_assets(profile_name, chal, build_result).await?;
 
     let frontend_info =
-        frontend::update_frontend(profile_name, chal, build_result, &kube_results, &s3_urls)
+        frontend::render_frontend_info(profile_name, chal, build_result, &kube_results, &s3_urls)
             .await?;
 
     Ok(frontend_info)

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -119,20 +119,12 @@ pub async fn deploy_challenges(
 ) -> Result<Vec<()>> {
     let profile = get_profile_config(profile_name)?;
 
-    let mut md_file = File::create(format!("challenge-info-{profile_name}.md"))?;
-    md_file.write_all(b"# Challenge Information\n\n")?;
-    let md_lock = std::sync::Mutex::new(md_file);
-
     build_results
         .iter()
         .map(|(chal, build)| async {
             let chal_md = deploy_single_challenge(profile_name, chal, build)
                 .await
                 .with_context(|| format!("could not deploy challenge {:?}", chal.directory))?;
-
-            debug!("writing chal {:?} info to file", chal.directory);
-            md_lock.lock().unwrap().write_all(chal_md.as_bytes())?;
-
             Ok(())
         })
         .try_join_all()

--- a/src/init/example_values.rs
+++ b/src/init/example_values.rs
@@ -13,11 +13,11 @@ pub static DEFAULTS_RESOURCES_CPU: i64 = 1;
 pub static DEFAULTS_RESOURCES_MEMORY: &str = "500M";
 
 pub static POINTS_EASY_CLASS: &str = "easy";
-pub static POINTS_EASY_MIN: i64 = 200;
-pub static POINTS_EASY_MAX: i64 = 500;
+pub static POINTS_EASY_MIN: u32 = 200;
+pub static POINTS_EASY_MAX: u32 = 500;
 pub static POINTS_HARD_CLASS: &str = "hard";
-pub static POINTS_HARD_MIN: i64 = 300;
-pub static POINTS_HARD_MAX: i64 = 600;
+pub static POINTS_HARD_MIN: u32 = 300;
+pub static POINTS_HARD_MAX: u32 = 600;
 
 pub static PROFILES_PROFILE_NAME: &str = "default";
 pub static PROFILES_FRONTEND_URL: &str = "https://ctf.coolguy.invalid";

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -88,12 +88,12 @@ pub fn interactive_init() -> inquire::error::InquireResult<config::RcdsConfig> {
                         .with_help_message("The name of the point class.")
                         .with_placeholder(example_values::POINTS_EASY_CLASS)
                         .prompt()?,
-                    min: inquire::CustomType::<i64>::new("Minimum points:")
+                    min: inquire::CustomType::<u32>::new("Minimum points:")
                         .with_error_message("Please type a valid number.") // default parser calls std::u64::from_str
                         .with_help_message("The minimum number of points that challenges within this class are worth.") // too long to format
                         .with_default(example_values::POINTS_EASY_MIN)
                         .prompt()?,
-                    max: inquire::CustomType::<i64>::new("Maximum points:")
+                    max: inquire::CustomType::<u32>::new("Maximum points:")
                         .with_error_message("Please type a valid number.") // default parser calls std::u64::from_str
                         .with_help_message("The maximum number of points that challenges within this class are worth.") // too long to format
                         .with_default(example_values::POINTS_EASY_MAX)

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -13,6 +13,8 @@ const VALID_CHAL: &str = r#"
     description: just a test challenge
     point_class: example
 
+    challenge_id: asdf
+
     flag:
         text: test{it-works}
 
@@ -87,6 +89,7 @@ fn challenge_two_levels() {
 
                 category: "foo".to_string(),
                 directory: PathBuf::from("foo/test"),
+                challenge_id: "asdf".to_string(),
 
                 flag: FlagType::Text {
                     text: "test{it-works}".to_string()
@@ -128,6 +131,7 @@ fn challenge_missing_fields() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
         "#,
         )?;
 
@@ -138,6 +142,7 @@ fn challenge_missing_fields() {
             name: testchal
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{asdf}
@@ -151,6 +156,20 @@ fn challenge_missing_fields() {
             name: testchal
             author: nobody
             point_class: example
+            challenge_id: asdf
+
+            flag:
+                text: test{asdf}
+        "#,
+        )?;
+
+        let dir = jail.create_dir("test/noid")?;
+        jail.create_file(
+            dir.join("challenge.yaml"),
+            r#"
+            name: testchal
+            author: nobody
+            description: just a test challenge
 
             flag:
                 text: test{asdf}
@@ -161,7 +180,7 @@ fn challenge_missing_fields() {
         assert!(chals.is_err());
         let errs = chals.unwrap_err();
 
-        assert_eq!(errs.len(), 3);
+        assert_eq!(errs.len(), 4);
 
         Ok(())
     })
@@ -179,6 +198,7 @@ fn challenge_no_provides_or_pods() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -205,6 +225,8 @@ fn challenge_no_point_class() {
             name: testchal
             author: nobody
             description: just a test challenge
+            # point_class:
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -231,6 +253,7 @@ fn challenge_provide() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -318,6 +341,7 @@ fn challenge_provide_no_include() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -348,6 +372,7 @@ fn challenge_pods() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -425,6 +450,7 @@ fn challenge_pod_build() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -515,6 +541,7 @@ fn challenge_pod_env() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}
@@ -601,6 +628,7 @@ fn challenge_pod_bad_env() {
             author: nobody
             description: just a test challenge
             point_class: example
+            challenge_id: asdf
 
             flag:
                 text: test{it-works}

--- a/src/tests/parsing/challenges.rs
+++ b/src/tests/parsing/challenges.rs
@@ -121,7 +121,7 @@ fn challenge_three_levels() {
 }
 
 #[test]
-fn challenge_missing_fields() {
+fn challenge_no_flag() {
     figment::Jail::expect_with(|jail| {
         let dir = jail.create_dir("test/noflag")?;
         jail.create_file(
@@ -135,6 +135,23 @@ fn challenge_missing_fields() {
         "#,
         )?;
 
+        let chals = parse_all();
+        assert!(chals.is_err());
+        let errs = chals.unwrap_err();
+
+        assert_eq!(errs.len(), 1);
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "test/noflag/challenge.yaml": missing field `flag`"#
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn challenge_no_author() {
+    figment::Jail::expect_with(|jail| {
         let dir = jail.create_dir("test/noauthor")?;
         jail.create_file(
             dir.join("challenge.yaml"),
@@ -149,6 +166,23 @@ fn challenge_missing_fields() {
         "#,
         )?;
 
+        let chals = parse_all();
+        assert!(chals.is_err());
+        let errs = chals.unwrap_err();
+
+        assert_eq!(errs.len(), 1);
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "test/noauthor/challenge.yaml": missing field `author`"#
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn challenge_no_description() {
+    figment::Jail::expect_with(|jail| {
         let dir = jail.create_dir("test/nodescrip")?;
         jail.create_file(
             dir.join("challenge.yaml"),
@@ -163,6 +197,23 @@ fn challenge_missing_fields() {
         "#,
         )?;
 
+        let chals = parse_all();
+        assert!(chals.is_err());
+        let errs = chals.unwrap_err();
+
+        assert_eq!(errs.len(), 1);
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "test/nodescrip/challenge.yaml": missing field `description`"#
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn challenge_no_id() {
+    figment::Jail::expect_with(|jail| {
         let dir = jail.create_dir("test/noid")?;
         jail.create_file(
             dir.join("challenge.yaml"),
@@ -180,7 +231,11 @@ fn challenge_missing_fields() {
         assert!(chals.is_err());
         let errs = chals.unwrap_err();
 
-        assert_eq!(errs.len(), 4);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "test/noid/challenge.yaml": missing field `challenge_id`"#
+        );
 
         Ok(())
     })
@@ -354,7 +409,13 @@ fn challenge_provide_no_include() {
         let chals = parse_all();
         assert!(chals.is_err());
         let errs = chals.unwrap_err();
+
         assert_eq!(errs.len(), 1);
+        // TODO: fix this really bad error message!
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "foo/test/challenge.yaml": data did not match any variant of untagged enum ProvideConfig for key "default.provide.0" in foo/test/challenge.yaml YAML file"#
+        );
 
         Ok(())
     })
@@ -649,7 +710,12 @@ fn challenge_pod_bad_env() {
         let chals = parse_all();
         assert!(chals.is_err());
         let errs = chals.unwrap_err();
+
         assert_eq!(errs.len(), 1);
+        assert_eq!(
+            format!("{:#}", errs[0]),
+            r#"failed to parse challenge config "foo/test/challenge.yaml": could not parse envvar=value from "FOO" (missing '='?)"#
+        );
 
         Ok(())
     })

--- a/tests/repo/misc/garf/challenge.yaml
+++ b/tests/repo/misc/garf/challenge.yaml
@@ -6,6 +6,8 @@ description: |
 # corresponds to point values in rcds.yaml, or default
 point_class: simple
 
+challenge_id: f41269
+
 # alternatively, flag: dam{wtf}
 flag:
   text: dam{garf}

--- a/tests/repo/misc/survey/challenge.yaml
+++ b/tests/repo/misc/survey/challenge.yaml
@@ -1,0 +1,9 @@
+name: survey
+author: Management
+description: |
+  worth one point! (probably)
+
+difficulty: survey
+
+flag:
+  text: dam{wow_survey}

--- a/tests/repo/misc/survey/challenge.yaml
+++ b/tests/repo/misc/survey/challenge.yaml
@@ -5,5 +5,7 @@ description: |
 
 point_class: survey
 
+challenge_id: '44c41a'
+
 flag:
   text: dam{wow_survey}

--- a/tests/repo/misc/survey/challenge.yaml
+++ b/tests/repo/misc/survey/challenge.yaml
@@ -3,7 +3,7 @@ author: Management
 description: |
   worth one point! (probably)
 
-difficulty: survey
+point_class: survey
 
 flag:
   text: dam{wow_survey}

--- a/tests/repo/pwn/notsh/Dockerfile
+++ b/tests/repo/pwn/notsh/Dockerfile
@@ -1,10 +1,10 @@
 # IMAGE 1: build challenge
 # @AUTHOR: if your chal doesn't build seperately from being run (i.e. Python),
 #          delete all of the IMAGE 1 code
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 # @AUTHOR: build requirements here
-RUN apt-get -qq update && apt-get -qq --no-install-recommends install build-essential
+RUN apt-get update && apt-get -qq --no-install-recommends install build-essential
 
 WORKDIR /build
 
@@ -15,10 +15,10 @@ RUN make container
 
 # IMAGE 2: run challenge
 # @AUTHOR: feel free to change base image as necessary (i.e. python, node)
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 # @AUTHOR: run requirements here
-RUN apt-get -qq update && apt-get -qq --no-install-recommends install xinetd
+RUN apt-get update && apt-get -qq --no-install-recommends install xinetd
 
 # copy binary
 WORKDIR /chal

--- a/tests/repo/pwn/notsh/challenge.yaml
+++ b/tests/repo/pwn/notsh/challenge.yaml
@@ -5,6 +5,8 @@ description: |-
 
   `nc {{host}} {{port}}`
 
+challenge_id: bbbbbb
+
 provide:
   - from: main
     as: notsh.zip

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -21,11 +21,15 @@ point_classes:
     max: 1337
   - name: "simple"
     min: 100
-    max: 500
+    max: 50
+  - name: "survey"
+    min: 1
+    max: 1
 
 deploy:
   # control challenge deployment status explicitly per environment/profile
   testing:
+    misc/survey: true
     misc/garf: true
     pwn/notsh: true
     web/bar: true

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -20,8 +20,8 @@ point_classes:
     min: 100
     max: 1337
   - name: "simple"
-    min: 100
-    max: 50
+    min: 50
+    max: 100
   - name: "survey"
     min: 1
     max: 1

--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -33,7 +33,7 @@ deploy:
 profiles:
   # configure per-environment credentials etc
   testing:
-    frontend_url: https://frontend.example
+    frontend_url: https://httpbin.org/anything
     frontend_token: secretsecretsecret
     challenges_domain: chals.frontend.example
     kubecontext: testcluster

--- a/tests/repo/web/bar/challenge.yaml
+++ b/tests/repo/web/bar/challenge.yaml
@@ -5,6 +5,8 @@ description: |
 
   {{ url }}
 
+challenge_id: cccccc
+
 flag:
   file: ./site_source/flag
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -40,7 +40,6 @@ start_stuff (){
   $(dockpod) network connect k3d-beavercds tests-registry-server-1
 
   # export variables if sourced or echo them if run
-  export BEAVERCDS_REGISTRY_DOMAIN="localhost:5000/testing"
   export BEAVERCDS_PROFILES_TESTING_KUBECONTEXT="k3d-$CLUSTER_NAME"
   export BEAVERCDS_PROFILES_TESTING_S3_ENDPOINT="http://localhost:9000"
   export BEAVERCDS_PROFILES_TESTING_S3_REGION=""


### PR DESCRIPTION
@cacama-valvata has provided the schema for what frontend wants for challenge state. This implements that instead of the temporary markdown writeout that we hacked in last year.

This also includes some temporary hacky updates to the challenge `difficulty` field so that it now matches the frontend difficulty config that was moved to be a string instead of an int. This is hacky and the parsing/validation should happen at parse time instead of deploy time but this is enough to make this functional and will be cleaned up as part of #71 anyway.

Resolves #62.
Resolves #13.