### PR TITLE
Show correct reference link to external-dns chart

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -42,8 +42,8 @@ pub fn run(_interactive: &bool, placeholders: &bool, blank: &bool, force: &bool)
     f.write_all(configuration.as_bytes())?;
 
     // Note about external-dns
-    warn!("Note: external-dns configuration settings will need to be provided in rcds.yaml after file creation, under the `profiles.name.dns` key.");
-    warn!("Reference: https://github.com/bitnami/charts/tree/main/bitnami/external-dns");
+    warn!("Note: external-dns configuration settings will need to be provided in rcds.yaml after file creation, under the `profiles.<name>.dns` key.");
+    warn!("Reference: https://kubernetes-sigs.github.io/external-dns/latest/charts/external-dns/");
 
     Ok(())
 }


### PR DESCRIPTION
We are using the official external-dns chart now and this link was not updated in the init branch after we made the change in the post-DamCTF PR.

See https://github.com/osusec/beavercds-backend/issues/51.