### PR TITLE
Add mock frontend server for local test infra

### DIFF
--- a/tests/repo/rcds.yaml
+++ b/tests/repo/rcds.yaml
@@ -33,7 +33,7 @@ deploy:
 profiles:
   # configure per-environment credentials etc
   testing:
-    frontend_url: https://frontend.example
+    frontend_url: http://mock_frontend.localhost:8080
     frontend_token: secretsecretsecret
     challenges_domain: chals.frontend.example
     kubecontext: testcluster

--- a/tests/services.compose.yaml
+++ b/tests/services.compose.yaml
@@ -38,3 +38,29 @@ services:
         /usr/bin/mc anonymous set download myminio/testbucket;
         exit 0;
       "
+
+  mock_frontend:
+    image: nginx:alpine
+    ports:
+      - 8080:80
+    entrypoint:
+      - sh
+      - -c
+      - |
+        cat <<'EOF' > /etc/nginx/conf.d/default.conf
+        server {
+          listen 80;
+          default_type application/json;
+
+          location /api/checkaccess {
+            return 200 '{"status":"ok"}';
+          }
+
+          location /api/resolvestate {
+            limit_except POST {
+              return 200 '{"current":[],"removed":[]}';
+            }
+          }
+        }
+        EOF
+        nginx -g 'daemon off;'


### PR DESCRIPTION
The frontend deployment code in #81 expects a response from the frontend, and the placeholder/httpbin url does not satisfy that schema. Add a mock api that behaves just enough to allow local testing to deploy without error.